### PR TITLE
Artifacts and proxy dev

### DIFF
--- a/activeLearner.py
+++ b/activeLearner.py
@@ -169,8 +169,7 @@ class ActiveLearning():
         else:
             self.action = None
 
-        query = self.querier.buildQuery(self.model, self.stateDict, self.sampleDict, self.action)  # pick Samples to be scored
-
+        query = self.querier.buildQuery(self.model, self.stateDict, self.sampleDict, action=self.action, comet=self.comet)  # pick Samples to be scored
         tf = time.time()
         printRecord('Query generation took {} seconds'.format(int(tf-t0)))
 
@@ -180,6 +179,9 @@ class ActiveLearning():
         printRecord('Oracle scored' + bcolors.OKBLUE + ' {} '.format(len(scores)) + bcolors.ENDC + 'queries with average score of' + bcolors.OKGREEN + ' {:.3f}'.format(np.average(scores)) + bcolors.ENDC)
         if not self.config.dataset.type == 'toy':
             printRecord('Oracle scoring took {} seconds'.format(int(tf-t0)))
+
+        if self.comet:
+            self.comet.log_histogram_3d(scores,name='query scores',step=self.pipeIter)
 
         self.updateDataset(query, scores) # add scored Samples to dataset
 
@@ -254,12 +256,24 @@ class ActiveLearning():
 
         if self.config.dataset.type == 'toy': # we can check the test error against a huge random dataset
             self.largeModelEvaluation()
-
+            if self.comet:
+                self.comet.log_metric(name='proxy loss on best 10% of large random dataset',value = self.bottomTenLoss[0], step=self.pipeIter)
+                self.comet.log_metric(name='proxy loss on large random dataset', value = self.totalLoss[0], step=self.pipeIter)
 
         if self.pipeIter == 0: # if it's the first round, initialize, else, append
             self.stateDictRecord = [self.stateDict]
         else:
             self.stateDictRecord.append(self.stateDict)
+
+        if self.comet:
+            self.comet.log_histogram_3d(energies, name='model state sampling run energies', step = self.pipeIter)
+            self.comet.log_histogram_3d(np.sqrt(uncertainties), name='model state sampling run std deviations', step = self.pipeIter)
+            self.comet.log_histogram_3d(minClusterEns[:self.config.querier.model_state_size], name='model state energies', step=self.pipeIter)
+            self.comet.log_histogram_3d(np.sqrt(minClusterVars[:self.config.querier.model_state_size]), name='model state std deviations', step=self.pipeIter)
+            self.comet.log_histogram_3d(internalDist, name='model state internal distance', step=self.pipeIter)
+            self.comet.log_histogram_3d(datasetDist, name='model state distance from dataset', step=self.pipeIter)
+            self.comet.log_histogram_3d(randomDist, name='model state distance from large random sample', step=self.pipeIter)
+            self.comet.log_histogram_3d(self.testMinima[-1], name='proxy model test minima', step=self.pipeIter)
 
 
     def getReward(self,bestEns,bestVars):
@@ -270,43 +284,48 @@ class ActiveLearning():
         :return:
         '''
         # get the best results in the standardized basis
-        stdEns = (bestEns - self.model.mean)/self.model.std
-        stdDevs = np.sqrt(bestVars) / self.model.std
-        adjustedEns = stdEns + stdDevs # consider std dev as an uncertainty envelope and take the high end
-        bestStdAdjusted = np.amin(adjustedEns)
+        best_ens_standardized = (bestEns - self.model.mean)/self.model.std
+        standardized_standard_deviations = np.sqrt(bestVars) / self.model.std
+        adjusted_standardized_energies = best_ens_standardized + standardized_standard_deviations # consider std dev as an uncertainty envelope and take the high end
+        best_standardized_adjusted_energy = np.amin(adjusted_standardized_energies)
 
         # convert to raw outputs basis
-        bestSoFar = bestEns[np.argmin(adjustedEns)]
-        bestSoFarVar = bestVars[np.argmin(adjustedEns)]
-        bestRawAdjusted = bestSoFar + bestSoFarVar
+        adjusted_energies = bestEns + np.sqrt(bestVars)
+        best_adjusted_energy = np.amin(adjusted_energies) # best energy, adjusted for uncertainty
         if self.pipeIter == 0:
             self.reward = 0 # first iteration - can't define a reward
             self.cumulativeReward = 0
             self.rewardList = np.zeros(self.config.al.n_iter)
-            self.prevIterBest = [bestRawAdjusted]
+            self.prevIterBest = [best_adjusted_energy]
         else: # calculate reward using current standardization
             stdPrevIterBest = (self.prevIterBest[-1] - self.model.mean)/self.model.std
-            self.reward = -(bestStdAdjusted - stdPrevIterBest) # reward is the delta between variance-adjusted energies in the standardized basis (smaller is better)
+            self.reward = -(best_standardized_adjusted_energy - stdPrevIterBest) # reward is the delta between variance-adjusted energies in the standardized basis (smaller is better)
             self.rewardList[self.pipeIter] = self.reward
             self.cumulativeReward = sum(self.rewardList)
-            self.prevIterBest.append(bestRawAdjusted)
+            self.prevIterBest.append(best_adjusted_energy)
 
-        printRecord('Iteration best uncertainty-adjusted result = {:.3f}, previous best = {:.3f}, reward = {:.3f}, cumulative reward = {:.3f}'.format(bestRawAdjusted, self.prevIterBest[-1], self.reward, self.cumulativeReward))
+        printRecord('Iteration best uncertainty-adjusted result = {:.3f}, previous best = {:.3f}, reward = {:.3f}, cumulative reward = {:.3f}'.format(best_adjusted_energy, self.prevIterBest[-1], self.reward, self.cumulativeReward))
 
         if self.config.dataset.type == 'toy': # if it's  a toy dataset, report the cumulative performance against the known minimum
             stdTrueMinimum = (self.trueMinimum - self.model.mean) / self.model.std
             if self.pipeIter == 0:
-                self.tot_score_yaxis = [1 - np.abs(stdTrueMinimum - bestStdAdjusted) / np.abs(stdTrueMinimum)]
+                self.abs_score = [1 - np.abs(self.trueMinimum - best_adjusted_energy) / np.abs(self.trueMinimum)]
+                self.cumulativeScore=0
             elif self.pipeIter > 0:
                 # we will compute the distance from our best answer to the correct answer and integrate it over the number of samples in the dataset
                 xaxis = self.config.dataset_size + np.arange(0,self.pipeIter + 1) * self.config.al.queries_per_iter # how many samples in the dataset used for each
-                self.tot_score_yaxis.append(1 - np.abs(stdTrueMinimum - bestStdAdjusted) / np.abs(stdTrueMinimum)) # compute proximity to correct answer in standardized basis
-                self.cumulativeScore = np.trapz(self.tot_score_yaxis, x=xaxis)
+                self.abs_score.append(1 - np.abs(self.trueMinimum - best_adjusted_energy) / np.abs(self.trueMinimum)) # compute proximity to correct answer in standardized basis
+                self.cumulativeScore = np.trapz(self.abs_score, x=xaxis)
                 self.normedCumScore = self.cumulativeScore / xaxis[-1]
-                printRecord('Total score is {:.3f} and {:.5f} per-sample after {} samples'.format(self.tot_score_yaxis[-1], self.normedCumScore, xaxis[-1]))
+                printRecord('Total score is {:.3f} and {:.5f} per-sample after {} samples'.format(self.abs_score[-1], self.normedCumScore, xaxis[-1]))
             else:
                 print('Error! Pipeline iteration cannot be negative')
                 sys.exit()
+
+            if self.comet:
+                self.comet.log_metric(name = "absolute score", value = self.abs_score[-1], step = self.pipeIter)
+                self.comet.log_metric(name = "cumulative score", value = self.cumulativeScore, step = self.pipeIter)
+                self.comet.log_metric(name = "reward", value = self.reward, step = self.pipeIter)
 
 
     def retrainModels(self, parallel=True):
@@ -316,6 +335,16 @@ class ActiveLearning():
                 self.resetModel(i)  # reset between ensemble estimators EVERY ITERATION of the pipeline
                 self.model.converge()  # converge model
                 testMins.append(np.amin(self.model.err_te_hist))
+                if self.comet:
+                    self.comet.log_curve("iter {} proxy {} train loss".format(i, self.pipeIter),
+                                         x=np.arange(len(self.model.err_tr_hist)).tolist(),
+                                         y=np.asarray(self.model.err_tr_hist).tolist()
+                                         )
+                    self.comet.log_curve("iter {} proxy {} test loss".format(i, self.pipeIter),
+                                         x=np.arange(len(self.model.err_te_hist)).tolist(),
+                                         y=np.asarray(self.model.err_te_hist).tolist()
+                                         )
+
             self.testMinima.append(testMins)
         else:
             del self.model
@@ -483,7 +512,7 @@ class ActiveLearning():
             outputDict['big dataset loss'] = self.totalLoss
             outputDict['bottom 10% loss'] = self.bottomTenLoss
             if self.pipeIter > 1:
-                outputDict['score record'] = self.tot_score_yaxis
+                outputDict['score record'] = self.abs_score
                 outputDict['cumulative score'] = self.cumulativeScore,
                 outputDict['per sample cumulative score'] = self.normedCumScore
         np.save('outputsDict', outputDict)
@@ -501,6 +530,9 @@ class ActiveLearning():
         # TODO separate between scores and q-scores
         dataset['samples'] = np.concatenate((dataset['samples'], oracleSequences))
         dataset['scores'] = np.concatenate((dataset['scores'], oracleScores))
+
+        if self.comet:
+            self.comet.log_histogram_3d(dataset['scores'], name='dataset scores', step=self.pipeIter)
 
         self.config.dataset_size = len(dataset['samples'])
 

--- a/activeLearner.py
+++ b/activeLearner.py
@@ -462,8 +462,9 @@ class ActiveLearning():
         self.oracleRecord = sampleDict
         self.trueMinimum = bestMin
 
-        self.comet.log_histogram_3d(sampleDict['energies'], name="energies_true",
-                step=0)
+        if self.comet:
+            self.comet.log_histogram_3d(sampleDict['energies'], name="energies_true",
+                    step=0)
 
 
     def saveOutputs(self):

--- a/activeLearner.py
+++ b/activeLearner.py
@@ -265,6 +265,7 @@ class ActiveLearning():
         else:
             self.stateDictRecord.append(self.stateDict)
 
+
         if self.comet:
             self.comet.log_histogram_3d(energies, name='model state sampling run energies', step = self.pipeIter)
             self.comet.log_histogram_3d(np.sqrt(uncertainties), name='model state sampling run std deviations', step = self.pipeIter)

--- a/activeLearner.py
+++ b/activeLearner.py
@@ -1,4 +1,4 @@
-
+from comet_ml import Experiment
 from argparse import Namespace
 import yaml
 from models import modelNet
@@ -29,6 +29,21 @@ class ActiveLearning():
         self.querier = Querier(self.config) # might as well initialize the querier here
         self.setup()
         self.getModelSize()
+        # Comet
+        if config.al.comet.project:
+            self.comet = Experiment(
+                project_name=config.al.comet.project, display_summary_level=0
+            )
+            if config.al.comet.tags:
+                if isinstance(config.al.comet.tags, list):
+                    self.comet.add_tags(config.al.comet.tags)
+                else:
+                    self.comet.add_tag(config.al.comet.tags)
+            self.comet.log_parameters(vars(config))
+            with open(Path(self.workDir) / "comet_al.url", "w") as f:
+                f.write(self.comet.url + "\n")
+        else:
+            self.comet = None
         # Save YAML config
         with open(self.workDir + '/config.yml', 'w') as f:
             yaml.dump(numpy2python(namespace2dict(self.config)), f, default_flow_style=False)
@@ -446,6 +461,9 @@ class ActiveLearning():
 
         self.oracleRecord = sampleDict
         self.trueMinimum = bestMin
+
+        self.comet.log_histogram_3d(sampleDict['energies'], name="energies_true",
+                step=0)
 
 
     def saveOutputs(self):

--- a/config/EX1.yml
+++ b/config/EX1.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX1
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX10.yml
+++ b/config/EX10.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
+  sample_method: "random"
   query_mode: "heuristic"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX1
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX11.yml
+++ b/config/EX11.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -14,7 +14,7 @@ seeds:
   toy_oracle: 0
 # Dataset
 dataset:
-  oracle: "nupack energy"
+  oracle: "nupack pairs"
   type: "toy"
   init_length: 100
   dict_size: 4
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX11
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX12.yml
+++ b/config/EX12.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -14,7 +14,7 @@ seeds:
   toy_oracle: 0
 # Dataset
 dataset:
-  oracle: "nupack energy"
+  oracle: "nupack pairs"
   type: "toy"
   init_length: 100
   dict_size: 4
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX12
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -82,17 +83,17 @@ gflownet:
   reward_max: 50000
 # Proxy model
 proxy:
-  model_type: "mlp"
+  model_type: "transformer"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
+  ensemble_size: 10
+  width: 256
   n_layers: 2
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX13.yml
+++ b/config/EX13.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -14,7 +14,7 @@ seeds:
   toy_oracle: 0
 # Dataset
 dataset:
-  oracle: "nupack energy"
+  oracle: "nupack pins"
   type: "toy"
   init_length: 100
   dict_size: 4
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX13
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX14.yml
+++ b/config/EX14.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -14,7 +14,7 @@ seeds:
   toy_oracle: 0
 # Dataset
 dataset:
-  oracle: "nupack energy"
+  oracle: "nupack pins"
   type: "toy"
   init_length: 100
   dict_size: 4
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX12
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -82,17 +83,17 @@ gflownet:
   reward_max: 50000
 # Proxy model
 proxy:
-  model_type: "mlp"
+  model_type: "transformer"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
+  ensemble_size: 10
+  width: 256
   n_layers: 2
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX2.yml
+++ b/config/EX2.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "mcmc"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX2
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX3.yml
+++ b/config/EX3.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -25,9 +25,9 @@ dataset:
 # AL
 al:
   sample_method: "gflownet"
-  query_mode: "heuristic"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX3
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX4.yml
+++ b/config/EX4.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -25,9 +25,9 @@ dataset:
 # AL
 al:
   sample_method: "gflownet"
-  query_mode: "heuristic"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX4
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,22 +58,22 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
   max_word_len: 1
-  early_stopping: 0.1
+  early_stopping: 0.01
   ema_alpha: 0.5
   learning_rate: 0.0001
   ckpt_period: 100
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX5.yml
+++ b/config/EX5.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX5
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 8
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX6.yml
+++ b/config/EX6.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX6
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -82,17 +83,17 @@ gflownet:
   reward_max: 50000
 # Proxy model
 proxy:
-  model_type: "mlp"
+  model_type: "transformer"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
+  ensemble_size: 10
+  width: 256
   n_layers: 2
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX7.yml
+++ b/config/EX7.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,10 +24,10 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX7
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -82,17 +83,17 @@ gflownet:
   reward_max: 50000
 # Proxy model
 proxy:
-  model_type: "mlp"
+  model_type: "transformer"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX8.yml
+++ b/config/EX8.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -16,7 +16,7 @@ seeds:
 dataset:
   oracle: "nupack energy"
   type: "toy"
-  init_length: 100
+  init_length: 10
   dict_size: 4
   variable_length: True
   min_length: 10
@@ -24,14 +24,14 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 200
   query_selection: "clustering"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
-  queries_per_iter: 100
+  queries_per_iter: 10
   mode: "training"
   q_batch_size: 32
   buffer_size: 10000
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX8
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/EX9.yml
+++ b/config/EX9.yml
@@ -2,8 +2,8 @@
 test_mode: False
 debug: True
 run_num: 0
-explicit_run_enumeration: False
-machine: "local"
+explicit_run_enumeration: True
+machine: "cluster"
 device: "cpu"
 workdir: !!null
 # Seeds
@@ -24,12 +24,12 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 50
   query_selection: "clustering"
-  minima_dist_cutoff: 0.25
+  minima_dist_cutoff: 0.4
   energy_uncertainty_tradeoff: 0
   queries_per_iter: 100
   mode: "training"
@@ -40,15 +40,16 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - EX9
+      - EX_runs
 # Querier
-querier:
+querier: 
   model_state_size: 30
   opt: "SGD"
   momentum: 0.95
   model_ckpt: !!null
   latent_space_width: 10
-# GFlowNet # model.pt
+# GFlowNet
 gflownet:
   device: "cpu"
   model_ckpt: model.pt
@@ -57,17 +58,17 @@ gflownet:
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 16
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
   batch_reward: 1
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
@@ -84,15 +85,15 @@ gflownet:
 proxy:
   model_type: "mlp"
   training_parallelism: False
-  ensemble_size: 2
-  width: 64
-  n_layers: 2
+  ensemble_size: 10
+  width: 256
+  n_layers: 4
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
   shuffle_dataset: True
 # MCMC
 mcmc:
-  sampling_time: 1000
-  num_samplers: 5
+  sampling_time: 10000
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -7,6 +7,7 @@ machine: "local"
 device: "cpu"
 workdir: !!null
 # Seeds
+comet_project: 'aptamer-al-mk'
 seeds:
   sampler: 0
   model: 0
@@ -14,17 +15,17 @@ seeds:
   toy_oracle: 0
 # Dataset
 dataset:
-  oracle: "nupack pins"
+  oracle: "linear"
   type: "toy"
   init_length: 100
   dict_size: 4
   variable_length: True
   min_length: 10
-  max_length: 60
+  max_length: 150
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
+  sample_method: "mcmc"
   query_mode: "energy"
   hyperparams_learning: False
   n_iter: 20
@@ -71,7 +72,7 @@ gflownet:
   comet:
     project: aptamer-al-mk
     tags:
-      - testing
+      - transformer_comet_tests
   early_stopping: 0.1
   ema_alpha: 0.5
   learning_rate: 0.0001
@@ -82,17 +83,17 @@ gflownet:
   reward_max: 10000
 # Proxy model
 proxy:
-  model_type: "mlp"
+  model_type: "transformer"
   training_parallelism: False
-  ensemble_size: 5
-  width: 256
-  n_layers: 4
+  ensemble_size: 2
+  width: 32
+  n_layers: 2
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 50
   shuffle_dataset: True
 # MCMC
 mcmc:
   sampling_time: 2000
-  num_samplers: 10
+  num_samplers: 2
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/gflownet.py
+++ b/gflownet.py
@@ -512,7 +512,7 @@ def make_mlp(layers_dim, act=nn.LeakyReLU(), tail=[]):
 
 
 class GFlowNetAgent:
-    def __init__(self, args, proxy=None):
+    def __init__(self, args, comet = None, proxy=None, alIter = 0):
         # Misc
         self.debug = args.debug
         self.device_torch = torch.device(args.gflownet.device)
@@ -528,22 +528,25 @@ class GFlowNetAgent:
         if self.reward_beta_period in [None, -1]:
             self.reward_beta_period = np.inf
         self.reward_max = args.gflownet.reward_max
+        self.alIter = alIter
+
         # Comet
-        if args.gflownet.comet.project:
-            self.comet = Experiment(
-                project_name=args.gflownet.comet.project, display_summary_level=0
-            )
-            if args.gflownet.comet.tags:
-                if isinstance(args.gflownet.comet.tags, list):
-                    self.comet.add_tags(args.gflownet.comet.tags)
-                else:
-                    self.comet.add_tag(args.gflownet.comet.tags)
-            self.comet.log_parameters(vars(args))
-            if "workdir" in args and Path(args.workdir).exists():
-                with open(Path(args.workdir) / "comet.url", "w") as f:
-                    f.write(self.comet.url + "\n")
-        else:
-            self.comet = None
+        #if args.gflownet.comet.project:
+        #    self.comet = Experiment(
+        #        project_name=args.gflownet.comet.project, display_summary_level=0
+        #    )
+        #    if args.gflownet.comet.tags:
+        #        if isinstance(args.gflownet.comet.tags, list):
+        #            self.comet.add_tags(args.gflownet.comet.tags)
+        #        else:
+        #            self.comet.add_tag(args.gflownet.comet.tags)
+        #    self.comet.log_parameters(vars(args))
+        #    if "workdir" in args and Path(args.workdir).exists():
+        #        with open(Path(args.workdir) / "comet.url", "w") as f:
+        #            f.write(self.comet.url + "\n")
+        #else:
+        #    self.comet = None
+        self.comet = comet
         # Environment
         self.env = AptamerSeq(
             args.gflownet.horizon,
@@ -841,13 +844,13 @@ class GFlowNetAgent:
                     dict(
                         zip(
                             [
-                                "mean_reward",
-                                "max_reward",
-                                "mean_energy",
-                                "min_energy",
-                                "mean_seq_length",
-                                "batch_size",
-                                "reward_beta",
+                                "mean_reward iter {}".format(self.alIter),
+                                "max_reward iter {}".format(self.alIter),
+                                "mean_energy iter {}".format(self.alIter),
+                                "min_energy iter {}".format(self.alIter),
+                                "mean_seq_length iter {}".format(self.alIter),
+                                "batch_size iter {}".format(self.alIter),
+                                "reward_beta iter {}".format(self.alIter),
                             ],
                             [
                                 np.mean(rewards),
@@ -886,7 +889,7 @@ class GFlowNetAgent:
                     self.comet.log_metrics(
                         dict(
                             zip(
-                                ["loss", "term_loss", "flow_loss"],
+                                ["loss iter {}".format(self.alIter), "term_loss iter {}".format(self.alIter), "flow_loss iter {}".format(self.alIter)],
                                 [loss.item() for loss in losses],
                             )
                         ),
@@ -894,7 +897,7 @@ class GFlowNetAgent:
                     )
                     if not self.lightweight:
                         self.comet.log_metric(
-                            "unique_states", np.unique(all_visited).shape[0], step=i
+                            "unique_states iter {}".format(self.alIter), np.unique(all_visited).shape[0], step=i
                         )
                 # Save intermediate model
             if not i % self.ckpt_period and self.model_path:
@@ -936,8 +939,8 @@ class GFlowNetAgent:
             torch.save(self.model.state_dict(), self.model_path)
 
         # Close comet
-        if self.comet:
-            self.comet.end()
+        #if self.comet:
+        #    self.comet.end()
 
     def sample(self, n_samples, horizon, nalphabet, min_word_len, max_word_len, proxy):
         times = {

--- a/gflownet.py
+++ b/gflownet.py
@@ -229,7 +229,7 @@ class AptamerSeq:
                 "innerprod": toyHamiltonian,
                 "potts": PottsEnergy,
                 "seqfold": seqfoldScore,
-                "nupack energy": lambda x: nupackScore(returnFunc = 'energy'),
+                "nupack energy": lambda x: nupackScore(returnFunc='energy'),
                 "nupack pairs": lambda x: -nupackScore(returnFunc='pairs'),
                 "nupack pins": lambda x: -nupackScore(returnFunc='hairpins'),
 
@@ -531,7 +531,7 @@ class GFlowNetAgent:
         # Comet
         if args.gflownet.comet.project:
             self.comet = Experiment(
-                project_name=args.gflownet.comet.project, display_summary_level=0, api_key="l3uy3rlY8fefx1QMxN3wIVFOO"
+                project_name=args.gflownet.comet.project, display_summary_level=0
             )
             if args.gflownet.comet.tags:
                 if isinstance(args.gflownet.comet.tags, list):

--- a/main.py
+++ b/main.py
@@ -72,6 +72,8 @@ def add_args(parser):
         help="If True, the next run be fresh, in directory 'run%d'%run_num; if False, regular behaviour. Note: only use this on fresh runs",
     )
     args2config.update({"explicit_run_enumeration": ["explicit_run_enumeration"]})
+    parser.add_argument("--comet_project", default=None, type=str)
+    args2config.update({"comet_project": ["comet_project"]})
     # Seeds
     parser.add_argument(
         "--sampler_seed",
@@ -230,6 +232,10 @@ def add_args(parser):
     args2config.update({"action_state_size": ["al", "action_state_size"]})
     parser.add_argument("--hyperparams_learning", action="store_true")
     args2config.update({"hyperparams_learning": ["al", "hyperparams_learning"]})
+    parser.add_argument(
+        "--tags_al", nargs="*", help="Comet.ml tags", default=[], type=str
+    )
+    args2config.update({"tags_al": ["al", "comet", "tags"]})
     # Querier
     parser.add_argument(
         "--model_state_size",
@@ -349,12 +355,10 @@ def add_args(parser):
     args2config.update({"bootstrap_tau": ["gflownet", "bootstrap_tau"]})
     parser.add_argument("--clip_grad_norm", default=0.0, type=float)
     args2config.update({"clip_grad_norm": ["gflownet", "clip_grad_norm"]})
-    parser.add_argument("--comet_project", default=None, type=str)
-    args2config.update({"comet_project": ["gflownet", "comet", "project"]})
     parser.add_argument(
-        "-t", "--tags", nargs="*", help="Comet.ml tags", default=[], type=str
+        "--tags_gfn", nargs="*", help="Comet.ml tags", default=[], type=str
     )
-    args2config.update({"tags": ["gflownet", "comet", "tags"]})
+    args2config.update({"tags_gfn": ["gflownet", "comet", "tags"]})
     parser.add_argument("--gflownet_annealing", action="store_true")
     args2config.update({"gflownet_annealing": ["gflownet", "annealing"]})
     parser.add_argument(
@@ -476,6 +480,10 @@ def process_config(config):
     config.gflownet.horizon = config.dataset.max_length
     config.gflownet.nalphabet = config.dataset.dict_size
     config.gflownet.func = config.dataset.oracle
+    # Comet: same project for AL and GFlowNet
+    if config.comet_project:
+        config.gflownet.comet.project = config.comet_project
+        config.al.comet.project = config.comet_project
     # Paths
     if not config.workdir and config.machine == "cluster":
         config.workdir = "/home/kilgourm/scratch/learnerruns"

--- a/models.py
+++ b/models.py
@@ -108,9 +108,6 @@ class modelNet():
         self.epochs = 0
 
         while (self.converged != 1):
-            if (self.epochs % 10 == 0) and self.config.debug:
-                printRecord("Model {} epoch {}".format(self.ensembleIndex, self.epochs))
-
             if self.epochs > 0: #  this allows us to keep the previous model if it is better than any produced on this run
                 self.train_net(tr)
             else:
@@ -122,6 +119,9 @@ class modelNet():
             # after training at least 10 epochs, check convergence
             if self.epochs >= self.config.history:
                 self.checkConvergence()
+
+            if (self.epochs % 10 == 0) and self.config.debug:
+                printRecord("Model {} epoch {} test loss {:.3f}".format(self.ensembleIndex, self.epochs, self.err_te_hist[-1]))
 
             self.epochs += 1
 
@@ -138,11 +138,11 @@ class modelNet():
         err_tr = []
         self.model.train(True)
         for i, trainData in enumerate(tr):
-            loss = self.getLoss(trainData)
-            err_tr.append(loss.data)  # record the loss
+            proxy_loss = self.getLoss(trainData)
+            err_tr.append(proxy_loss.data)  # record the loss
 
             self.optimizer.zero_grad()  # run the optimizer
-            loss.backward()
+            proxy_loss.backward()
             self.optimizer.step()
 
         self.err_tr_hist.append(torch.mean(torch.stack(err_tr)).cpu().detach().numpy())
@@ -384,12 +384,15 @@ class transformer(nn.Module):
         self.embedding = nn.Embedding(self.dictLen + 1, embedding_dim = self.embedDim)
 
         factory_kwargs = {'device': None, 'dtype': None}
-        self.self_attn = nn.MultiheadAttention(self.embedDim, self.heads, dropout=0, batch_first=False,**factory_kwargs)
-
         #encoder_layer = nn.TransformerEncoderLayer(self.embedDim, nhead = self.heads,dim_feedforward=self.hiddenDim, activation='gelu', dropout=0)
         #self.encoder = nn.TransformerEncoder(encoder_layer, num_layers = self.layers)
         self.decoder_layers = []
+        self.encoder_linear = []
+        self.self_attn_layers = []
         for i in range(self.layers):
+            self.encoder_linear.append(nn.Linear(self.embedDim,self.embedDim))
+            self.self_attn_layers.append(nn.MultiheadAttention(self.embedDim, self.heads, dropout=0, batch_first=False, **factory_kwargs))
+
             if i == 0:
                 in_dim = self.embedDim
             else:
@@ -398,16 +401,21 @@ class transformer(nn.Module):
             self.decoder_layers.append(nn.Linear(in_dim, out_dim))
 
         self.decoder_layers = nn.ModuleList(self.decoder_layers)
+        self.encoder_linear = nn.ModuleList(self.encoder_linear)
+        self.self_attn_layers = nn.ModuleList(self.self_attn_layers)
         self.output_layer = nn.Linear(self.hiddenDim,self.classes,bias=False)
 
     def forward(self,x):
         x_key_padding_mask = (x==0).clone().detach() # zero out the attention of empty sequence elements
         x = self.embedding(x.transpose(1,0).int()) # [seq, batch]
         x = self.positionalEncoder(x)
-        x = self.self_attn(x,x,x,key_padding_mask=x_key_padding_mask)[0] # self-attention over sequence
-        x = torch.mean(x,dim=0) # aggregate
         #x = self.encoder(x,src_key_padding_mask=x_key_padding_mask)
         #x = x.permute(1,0,2).reshape(x_key_padding_mask.shape[0], int(self.embedDim*self.maxLen))
+        for i in range(len(self.self_attn_layers)):
+            x = self.self_attn_layers[i](x,x,x,key_padding_mask=x_key_padding_mask)[0]
+            x = self.encoder_linear[i](x)
+
+        x = x.mean(dim=0) # mean aggregation
         for i in range(len(self.decoder_layers)):
             x = F.gelu(self.decoder_layers[i](x))
 

--- a/querier.py
+++ b/querier.py
@@ -23,7 +23,7 @@ class Querier():
         if self.config.al.query_mode == 'learned':
             pass
 
-    def buildQuery(self, model, statusDict, energySampleDict, action = None):
+    def buildQuery(self, model, statusDict, energySampleDict, action = None, comet=None,):
         """
         select the samples which will be sent to the oracle for scoring
         if we are dynamically updating hyperparameters, take an action
@@ -65,6 +65,11 @@ class Querier():
             scores = scores[inds]
 
             query = self.constructQuery(samples, scores, uncertainties, nQueries)
+
+            if comet:
+                comet.log_histogram_3d(self.sampleDict['scores'], name='sampler output scores', step=statusDict['iter'])
+                comet.log_histogram_3d(np.sqrt(uncertainties), name='sampler output std deviations', step=statusDict['iter'])
+                comet.log_histogram_3d(self.sampleDict['energies'], name='sampler output energies', step=statusDict['iter'])
 
         return query
 

--- a/querier.py
+++ b/querier.py
@@ -30,7 +30,7 @@ class Querier():
         :param sampleDict:
         :return:
         """
-
+        self.comet = comet
         if action is not None:
             self.updateHyperparams(action)
 
@@ -66,10 +66,10 @@ class Querier():
 
             query = self.constructQuery(samples, scores, uncertainties, nQueries)
 
-            if comet:
-                comet.log_histogram_3d(self.sampleDict['scores'], name='sampler output scores', step=statusDict['iter'])
-                comet.log_histogram_3d(np.sqrt(uncertainties), name='sampler output std deviations', step=statusDict['iter'])
-                comet.log_histogram_3d(self.sampleDict['energies'], name='sampler output energies', step=statusDict['iter'])
+            if self.comet:
+                self.comet.log_histogram_3d(self.sampleDict['scores'], name='sampler output scores', step=statusDict['iter'])
+                self.comet.log_histogram_3d(np.sqrt(uncertainties), name='sampler output std deviations', step=statusDict['iter'])
+                self.comet.log_histogram_3d(self.sampleDict['energies'], name='sampler output energies', step=statusDict['iter'])
 
         return query
 
@@ -165,11 +165,10 @@ class Querier():
                 'uncertainties': uncertainties,
                 'scores':scores
             }
-            if self.config.gflownet.annealing:
-                outputs = self.doAnnealing(scoreFunction, model, outputs)
+            outputs = self.doAnnealing(scoreFunction, model, outputs)
 
         elif method.lower() == "gflownet":
-            gflownet = GFlowNetAgent(self.config, proxy=model.raw)
+            gflownet = GFlowNetAgent(self.config, comet = self.comet, proxy=model.raw)
 
             t0 = time.time()
             gflownet.train()


### PR DESCRIPTION
Not sure if I made this fork properly from main - it looks like it has some earlier Alex commits inside. Every day I learn a little more about git. 

-> updated transformer model - now proxy can be 'mlp' or 'transformer'
--> transformer does one layer of pure self-attention, then does mean-aggregation, down to a single vector, which we put into a small MLP. We could do more attention / MLP alternation before aggregation if we wanted. Not sure what's optimal.
 -> Also put in comet logs for the important AL factors - scores, model state, training outputs and sampler outputs. 
 
 -> also, reworked the way we get rewards and scores. Should be 1) more readable as code and 2) absolute scores rather than relative ones should make the resulting plots more sensible.

Should be ready for testing of transformer as an upgraded proxy, as well as much easier-to-parse logging. 
