### PR TITLE
Take AptamerSeq out of gflownet.py

### DIFF
--- a/gflownet.py
+++ b/gflownet.py
@@ -301,19 +301,23 @@ class GFlowNetAgent:
         self.random_action_prob = args.gflownet.random_action_prob
         # Test set
         self.test_period = args.gflownet.test.period
-        self.test_score = args.gflownet.test.score
-        if args.gflownet.test.path:
-            self.df_test = pd.read_csv(args.gflownet.test.path, index_col=0)
+        if self.test_period in [None, -1]:
+            self.test_period = np.inf
+            self.df_test = None
         else:
-            self.df_test, test_set_times = make_approx_uniform_test_set(
-                path_base_dataset=args.gflownet.test.base,
-                score=self.test_score,
-                ntest=args.gflownet.test.n,
-                min_length=args.gflownet.test.min_length,
-                max_length=args.gflownet.horizon,
-                seed=args.gflownet.test.seed,
-                output_csv=args.gflownet.test.output,
-            )
+            self.test_score = args.gflownet.test.score
+            if args.gflownet.test.path:
+                self.df_test = pd.read_csv(args.gflownet.test.path, index_col=0)
+            else:
+                self.df_test, test_set_times = make_approx_uniform_test_set(
+                    path_base_dataset=args.gflownet.test.base,
+                    score=self.test_score,
+                    ntest=args.gflownet.test.n,
+                    min_length=args.gflownet.test.min_length,
+                    max_length=args.gflownet.horizon,
+                    seed=args.gflownet.test.seed,
+                    output_csv=args.gflownet.test.output,
+                )
         if self.df_test is not None:
             print("\nTest data")
             print(f"\tAverage score: {self.df_test[self.test_score].mean()}")

--- a/gflownet.py
+++ b/gflownet.py
@@ -355,7 +355,7 @@ class AptamerSeq:
         seq = np.where(obs_mat)[1]
         return seq
 
-    def seq2letters(self, seq, alphabet={0: "A", 1: "T", 2: "C", 3: "G"}):
+    def seq2letters(self, seq, alphabet={0: "A", 1: "T", 2: "G", 3: "C"}):
         """
         Transforms a sequence given as a list of indices into a sequence of letters
         according to an alphabet.

--- a/main.py
+++ b/main.py
@@ -371,8 +371,8 @@ def add_args(parser):
     args2config.update({"clip_grad_norm": ["gflownet", "clip_grad_norm"]})
     parser.add_argument("--random_action_prob", default=0.0, type=float)
     args2config.update({"random_action_prob": ["gflownet", "random_action_prob"]})
-    parser.add_argument("--comet_project", default=None, type=str)
-    args2config.update({"comet_project": ["gflownet", "comet", "project"]})
+    parser.add_argument("--gflownet_comet_project", default=None, type=str)
+    args2config.update({"gflownet_comet_project": ["gflownet", "comet", "project"]})
     parser.add_argument(
         "--tags_gfn", nargs="*", help="Comet.ml tags", default=[], type=str
     )

--- a/oracle.py
+++ b/oracle.py
@@ -367,7 +367,7 @@ class Oracle():
         return out
 
 
-    def nupackScore(self,queries,returnFunc = 'energy'):
+    def nupackScore(self, queries, returnFunc='energy'):
         # Nupack requires Linux OS.
         #use nupack instead of seqfold - more stable and higher quality predictions in general
         #returns the energy of the most probable structure only
@@ -380,10 +380,9 @@ class Oracle():
         sequences = self.numbers2letters(queries)
 
         energies = np.zeros(len(sequences))
-        strings = []
         nPins = np.zeros(len(sequences)).astype(int)
         nPairs = 0
-        ssStrings = np.zeros(len(sequences),dtype=object)
+        ssStrings = np.zeros(len(sequences), dtype=object)
 
         # parallel evaluation - fast
         strandList = []
@@ -413,7 +412,6 @@ class Oracle():
                             nPins[i] += 1
         if returnFunc == 'pairs':
             nPairs = np.asarray([ssString.count('(') for ssString in ssStrings]).astype(int)
-
 
         if returnFunc == 'energy':
             return energies


### PR DESCRIPTION
The main change is the separation of the class `AptamerSeq` as a new script. Several reasons for this:
* It improves the logic, in my opinion: one thing is the funcionality for training GFlowNet (`gflownet.py`); another thing is the representation of the data it makes use of (now `aptamers.py`)
* It makes it easier to extend.
* `gflownet.py` was getting too long ^^

There are a few other improvements and minor changes. For example, I extended the computation of logq for DAGs (word actions), though in practice it takes way too long to be computed (combinatorially many trajectories).