### PR TITLE
Enable adding sequences from empirical distribution (current AL data) to GFN batches

### DIFF
--- a/gflownet.py
+++ b/gflownet.py
@@ -1147,7 +1147,7 @@ def np2df(test_path, score, al_init_length, al_queries_per_iter, pct_test, data_
         indices_tr = indices[n_tt:] + idx
         df.loc[indices_tt, "test"] = True
         df.loc[indices_tr, "train"] = True
-        idx += (it + 1) * al_queries_per_iter
+        idx += al_queries_per_iter
     return df
 
 

--- a/querier.py
+++ b/querier.py
@@ -170,7 +170,7 @@ class Querier():
 
         elif method.lower() == "gflownet":
             gflownet = GFlowNetAgent(self.config, comet = self.comet, proxy=model.raw,
-                    al_iter=seedInd, test_path='datasets/' + self.config.dataset.oracle + '.npy')
+                    al_iter=seedInd, data_path='datasets/' + self.config.dataset.oracle + '.npy')
 
             t0 = time.time()
             gflownet.train()


### PR DESCRIPTION
To achieve this:
1. The path to the current data set is passed to GFloNet from `querier.py`
2. The data is split into _train_ and _test_, ensuring that as the data set grows, the split is consistent with previous iterations.
3. The test split is used for computing the correlation between scores and log q
4. The train split is used to populate a percentage of the training batches.