### PR TITLE
Epistemic uncertainty

### DIFF
--- a/activeLearner.py
+++ b/activeLearner.py
@@ -160,19 +160,19 @@ class ActiveLearning():
         '''
 
         t0 = time.time()
-        self.retrainModels(parallel=self.config.proxy.training_parallelism)
+        self.retrainModels()
         tf = time.time()
         printRecord('Retraining took {} seconds'.format(int(tf-t0)))
 
         t0 = time.time()
         self.getModelState() # run energy-only sampling and create model state dict
-        if self.config.al.hyperparams_learning:# and (self.pipeIter > 0):
-            model_state_prev, model_state_curr = self.agent.updateModelState(self.stateDict, self.model)
-            if model_state_prev is not None:
-                self.agent.push_to_buffer(model_state_prev, self.action, model_state_curr, self.reward, self.terminal)
-            self.action = self.agent.getAction()
-        else:
-            self.action = None
+        #if self.config.al.hyperparams_learning:# and (self.pipeIter > 0):
+        #    model_state_prev, model_state_curr = self.agent.updateModelState(self.stateDict, self.model)
+        #    if model_state_prev is not None:
+        #        self.agent.push_to_buffer(model_state_prev, self.action, model_state_curr, self.reward, self.terminal)
+        #    self.action = self.agent.getAction()
+        #else:
+        #    self.action = None
 
         query = self.querier.buildQuery(self.model, self.stateDict, self.sampleDict, action=self.action, comet=self.comet)  # pick Samples to be scored
         tf = time.time()
@@ -218,25 +218,25 @@ class ActiveLearning():
         uncertainties = self.sampleDict['uncertainties']
 
         # agglomerative clustering
-        clusters, clusterEns, clusterVars = doAgglomerativeClustering(samples,energies,uncertainties,self.config.dataset.dict_size,cutoff=normalizeDistCutoff(self.config.al.minima_dist_cutoff))
-        clusterSizes, avgClusterEns, minClusterEns, avgClusterVars, minClusterVars, minClusterSamples = clusterAnalysis(clusters, clusterEns, clusterVars)
+        clusters, clusterEns, clusterstd_dev = doAgglomerativeClustering(samples,energies,uncertainties,self.config.dataset.dict_size,cutoff=normalizeDistCutoff(self.config.al.minima_dist_cutoff))
+        clusterSizes, avgClusterEns, minClusterEns, avgClusterstd_dev, minClusterstd_dev, minClusterSamples = clusterAnalysis(clusters, clusterEns, clusterstd_dev)
 
         #clutering alternative - just include sample-by-sample
         #bestInds = sortTopXSamples(samples[np.argsort(scores)], nSamples=len(samples), distCutoff=0.1)  # sort out the best, and at least minimally distinctive samples
 
         if len(clusters) < self.config.querier.model_state_size: # if we don't have enough clusters for the model, pad with random samples from the sampling run
-            minClusterSamples, minClusterEns, minClusterVars = self.addRandomSamples(samples, energies, uncertainties, minClusterSamples, minClusterEns, minClusterVars)
+            minClusterSamples, minClusterEns, minClusterstd_dev = self.addRandomSamples(samples, energies, uncertainties, minClusterSamples, minClusterEns, minClusterstd_dev)
 
         # get distances to relevant datasets
         internalDist, datasetDist, randomDist = self.getDataDists(minClusterSamples[:self.config.querier.model_state_size])
-        self.getReward(minClusterEns, minClusterVars)
+        self.getReward(minClusterEns, minClusterstd_dev)
 
         self.stateDict = {
             'test loss': np.average(self.testMinima), # losses are evaluated on standardized data, so we do not need to re-standardize here
             'test std': np.sqrt(np.var(self.testMinima)),
             'all test losses': self.testMinima,
             'best cluster energies': (minClusterEns[:self.config.querier.model_state_size] - self.model.mean) / self.model.std, # standardize according to dataset statistics
-            'best cluster deviations': np.sqrt(minClusterVars[:self.config.querier.model_state_size]) / self.model.std,
+            'best cluster deviations': minClusterstd_dev[:self.config.querier.model_state_size] / self.model.std,
             'best cluster samples': minClusterSamples[:self.config.querier.model_state_size],
             'best clusters internal diff': internalDist,
             'best clusters dataset diff': datasetDist,
@@ -248,11 +248,11 @@ class ActiveLearning():
             'reward': self.reward
         }
 
-        printRecord('%d '%self.config.proxy.ensemble_size + f'Model ensemble training converged with average test loss of {bcolors.OKCYAN}%.5f{bcolors.ENDC}' % np.average(np.asarray(self.testMinima[-self.config.proxy.ensemble_size:])) + f' and std of {bcolors.OKCYAN}%.3f{bcolors.ENDC}'%(np.sqrt(np.var(self.testMinima))))
+        printRecord('%d '%self.config.proxy.ensemble_size + f'Model ensemble training converged with average test loss of {bcolors.OKCYAN}%.5f{bcolors.ENDC}' % np.average(np.asarray(self.testMinima[-self.config.proxy.ensemble_size:])) + f' and std of {bcolors.OKCYAN}%.3f{bcolors.ENDC}'%(np.sqrt(np.var(self.testMinima[-self.config.proxy.ensemble_size:]))))
         printRecord('Model state contains {} samples'.format(self.config.querier.model_state_size) +
                     ' with minimum energy' + bcolors.OKGREEN + ' {:.2f},'.format(np.amin(minClusterEns)) + bcolors.ENDC +
                     ' average energy' + bcolors.OKGREEN +' {:.2f},'.format(np.average(minClusterEns[:self.config.querier.model_state_size])) + bcolors.ENDC +
-                    ' and average std dev' + bcolors.OKCYAN + ' {:.2f}'.format(np.average(np.sqrt(minClusterVars[:self.config.querier.model_state_size]))) + bcolors.ENDC)
+                    ' and average std dev' + bcolors.OKCYAN + ' {:.2f}'.format(np.average(minClusterstd_dev[:self.config.querier.model_state_size])) + bcolors.ENDC)
         printRecord("Best sample in model state is {}".format(numbers2letters(minClusterSamples[np.argmin(minClusterEns)])))
         printRecord('Sample average mutual distance is ' + bcolors.WARNING +'{:.2f} '.format(np.average(internalDist)) + bcolors.ENDC +
                     'dataset distance is ' + bcolors.WARNING + '{:.2f} '.format(np.average(datasetDist)) + bcolors.ENDC +
@@ -273,9 +273,9 @@ class ActiveLearning():
 
         if self.comet:
             self.comet.log_histogram_3d(energies, name='model state sampling run energies', step = self.pipeIter)
-            self.comet.log_histogram_3d(np.sqrt(uncertainties), name='model state sampling run std deviations', step = self.pipeIter)
+            self.comet.log_histogram_3d(uncertainties, name='model state sampling run std deviations', step = self.pipeIter)
             self.comet.log_histogram_3d(minClusterEns[:self.config.querier.model_state_size], name='model state energies', step=self.pipeIter)
-            self.comet.log_histogram_3d(np.sqrt(minClusterVars[:self.config.querier.model_state_size]), name='model state std deviations', step=self.pipeIter)
+            self.comet.log_histogram_3d(minClusterstd_dev[:self.config.querier.model_state_size], name='model state std deviations', step=self.pipeIter)
             self.comet.log_histogram_3d(internalDist, name='model state internal distance', step=self.pipeIter)
             self.comet.log_histogram_3d(datasetDist, name='model state distance from dataset', step=self.pipeIter)
             self.comet.log_histogram_3d(randomDist, name='model state distance from large random sample', step=self.pipeIter)
@@ -291,12 +291,12 @@ class ActiveLearning():
         '''
         # get the best results in the standardized basis
         best_ens_standardized = (bestEns - self.model.mean)/self.model.std
-        standardized_standard_deviations = np.sqrt(bestVars) / self.model.std
+        standardized_standard_deviations = bestVars / self.model.std
         adjusted_standardized_energies = best_ens_standardized + standardized_standard_deviations # consider std dev as an uncertainty envelope and take the high end
         best_standardized_adjusted_energy = np.amin(adjusted_standardized_energies)
 
         # convert to raw outputs basis
-        adjusted_energies = bestEns + np.sqrt(bestVars)
+        adjusted_energies = bestEns + bestVars
         best_adjusted_energy = np.amin(adjusted_energies) # best energy, adjusted for uncertainty
         if self.pipeIter == 0:
             self.reward = 0 # first iteration - can't define a reward
@@ -334,7 +334,7 @@ class ActiveLearning():
                 self.comet.log_metric(name = "reward", value = self.reward, step = self.pipeIter)
 
 
-    def retrainModels(self, parallel=True):
+    def retrainModels(self):
         testMins = []
         for i in range(self.config.proxy.ensemble_size):
             self.resetModel(i)  # reset between ensemble estimators EVERY ITERATION of the pipeline
@@ -349,7 +349,6 @@ class ActiveLearning():
                     self.comet.log_metric('proxy test loss iter {}'.format(self.pipeIter), step=i, value=te_hist[i])
 
         self.testMinima.append(testMins)
-
 
 
     def loadEstimatorEnsemble(self):
@@ -367,6 +366,7 @@ class ActiveLearning():
         del self.model
         self.model = modelNet(self.config,0)
         self.model.loadEnsemble(ensemble)
+        self.model.getMinF()
 
         #print('Loaded {} estimators'.format(int(self.config.proxy.ensemble_size)))
 
@@ -409,12 +409,12 @@ class ActiveLearning():
         randomSamples = randomSamples[sortInds]
         randomScores = randomScores[sortInds]
 
-        modelScores, modelVars = [[],[]]
+        modelScores, modelStd = [[],[]]
         sampleLoader = data.DataLoader(randomSamples, batch_size = self.config.proxy.mbsize, shuffle=False, num_workers = 0, pin_memory=False)
         for i, testData in enumerate(sampleLoader):
-            score, variance = self.model.evaluate(testData.float(), output='Both')
+            score, std_dev = self.model.evaluate(testData.float(), output='Both')
             modelScores.extend(score)
-            modelVars.extend(variance)
+            modelStd.extend(std_dev)
 
         bestTenInd = numSamples // 10
         totalLoss = F.smooth_l1_loss((torch.Tensor(modelScores).float() - self.model.mean) / self.model.std, (torch.Tensor(randomScores).float() - self.model.mean) / self.model.std) # full dataset loss (standardized basis)

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -24,11 +24,11 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "gflownet"
-  query_mode: "heuristic"
+  sample_method: "random"
+  query_mode: "energy"
   hyperparams_learning: False
   n_iter: 5
-  query_selection: "clustering"
+  query_selection: "argmin"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
   queries_per_iter: 100
@@ -40,7 +40,7 @@ al:
   comet:
     project: aptamer-al-mk
     tags:
-      - EX_test_run
+      - GPU_gfn_test
 # Querier
 querier:
   model_state_size: 30
@@ -52,51 +52,51 @@ querier:
 gflownet:
   device: "cpu"
   model_ckpt: !!null #model.pt
-  progress: 1
+  progress: True
   opt: "adam"
   adam_beta1: 0.9
   adam_beta2: 0.999
   momentum: 0.9
-  mbsize: 64
+  mbsize: 128
   train_to_sample_ratio: 1
   n_hid: 256
   n_layers: 2
-  n_iter: 200
+  n_iter: 20000
   n_samples: 10000
   num_empirical_loss: 200000
-  batch_reward: 1
+  batch_reward: True
   bootstrap_tau: 0.0
   clip_grad_norm: 0.0
-  annealing: True
+  annealing: False
   post_annealing_samples: 100
   post_annealing_time: 1000
   min_word_len: 1
   max_word_len: 1
-  comet:
-    project: aptamer-al-mk
-    tags:
-      - testing
-  early_stopping: 0.1
+  early_stopping: 0.001
   ema_alpha: 0.5
   learning_rate: 0.0001
   ckpt_period: 100
   reward_beta_init: 1
   reward_beta_mult: 1.25
   reward_beta_period: 100
-  reward_max: 10000
+  reward_max: 50000
+  test:
+    path: !!null
+    period: 100
 # Proxy model
 proxy:
-  model_type: "mlp"
-  training_parallelism: False
-  ensemble_size: 5
-  width: 256
-  n_layers: 4
+  model_type: "transformer2"
+  ensemble_size: 2
+  width: 16
+  n_layers: 12
   mbsize: 10
   max_epochs: 200
   shuffle_dataset: True
+  uncertainty_estimation : "dropout"
+  dropout: 0.5
 # MCMC
 mcmc:
-  sampling_time: 2000
-  num_samplers: 10
+  sampling_time: 200
+  num_samplers: 2
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -4,7 +4,7 @@ debug: True
 run_num: 0
 explicit_run_enumeration: False
 machine: "local"
-device: "cpu"
+device: "cuda"
 workdir: !!null
 # Seeds
 seeds:
@@ -24,13 +24,16 @@ dataset:
   sample_tasks: 1
 # AL
 al:
-  sample_method: "random"
-  query_mode: "energy"
+  sample_method: "mcmc"
+  query_mode: "fancy_acquisition" # must be 'fancy_acquisition' for our new acquisition functions
+  acquisition_function : "ei"
   hyperparams_learning: False
-  n_iter: 5
+  n_iter: 10
   query_selection: "argmin"
   minima_dist_cutoff: 0.25
   energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
   queries_per_iter: 100
   mode: "training"
   q_batch_size: 32
@@ -50,7 +53,7 @@ querier:
   latent_space_width: 10
 # GFlowNet # model.pt
 gflownet:
-  device: "cpu"
+  device: "cuda"
   model_ckpt: !!null #model.pt
   progress: True
   opt: "adam"
@@ -85,18 +88,19 @@ gflownet:
     period: 100
 # Proxy model
 proxy:
-  model_type: "transformer2"
-  ensemble_size: 2
-  width: 16
-  n_layers: 12
+  model_type: "mlp"
+  ensemble_size: 1
+  width: 128
+  n_layers: 4
   mbsize: 10
   max_epochs: 200
   shuffle_dataset: True
   uncertainty_estimation : "dropout"
-  dropout: 0.5
+  dropout: 0.1
+  dropout_samples: 25
 # MCMC
 mcmc:
   sampling_time: 200
-  num_samplers: 2
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/main.py
+++ b/main.py
@@ -408,13 +408,6 @@ def add_args(parser):
     )
     args2config.update({"proxy_model_type": ["proxy", "model_type"]})
     parser.add_argument(
-        "--training_parallelism",
-        action="store_true",
-        default=False,
-        help="fast enough on GPU without paralellism - True doesn't always work on linux",
-    )
-    args2config.update({"training_parallelism": ["proxy", "training_parallelism"]})
-    parser.add_argument(
         "--proxy_model_ensemble_size",
         type=int,
         default=10,
@@ -447,6 +440,10 @@ def add_args(parser):
         help="give each model in the ensemble a uniquely shuffled dataset",
     )
     args2config.update({"proxy_shuffle_dataset": ["proxy", "shuffle_dataset"]})
+    parser.add_argument("--proxy_uncertainty_estimation", type=str, default="dropout", help="dropout or ensemble")
+    args2config.update({"proxy_uncertainty_estimation": ["proxy", "uncertainty_estimation"]})
+    parser.add_argument("--proxy_dropout", type=float, default = 0.5)
+    args2config.update({"proxy_dropout": ["proxy", "dropout"]})
     # MCMC
     parser.add_argument(
         "--mcmc_sampling_time",

--- a/querier.py
+++ b/querier.py
@@ -132,6 +132,10 @@ class Querier():
             c1 = 0.5 - self.config.al.energy_uncertainty_tradeoff / 2
             c2 = 0.5 + self.config.al.energy_uncertainty_tradeoff / 2
             scoreFunction = [c1, c2]  # put in user specified values (or functions) here
+        elif self.config.al.query_mode == 'fancy_acquisition':
+            c1 = 1
+            c2 = 1
+            scoreFunction = [c1, c2]
         else:
             raise ValueError(self.config.al.query_mode + 'is not a valid query function!')
 
@@ -158,12 +162,12 @@ class Querier():
 
         elif method.lower() == "random":
             samples = generateRandomSamples(10000, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length, oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
-            energies, uncertainties = model.evaluate(samples,output="Both")
-            scores = energies * scoreFunction[0] - scoreFunction[1] * np.asarray(np.sqrt(uncertainties))
+            energies, std_dev = model.evaluate(samples,output="Both")
+            scores = energies * scoreFunction[0] - scoreFunction[1] * np.asarray(std_dev)
             outputs = {
                 'samples': samples,
                 'energies': energies,
-                'uncertainties': uncertainties,
+                'uncertainties': std_dev,
                 'scores':scores
             }
             outputs = self.doAnnealing(scoreFunction, model, outputs)

--- a/utils.py
+++ b/utils.py
@@ -438,7 +438,7 @@ def samples2dict(samples):
         "samples": np.concatenate(samples["optimalSamples"]),
         "scores": np.concatenate(samples["optima"]),
         "energies": np.concatenate(samples["enAtOptima"]),
-        "uncertainties": np.concatenate(samples["varAtOptima"]),
+        "uncertainties": np.concatenate(samples["std_devAtOptima"]),
     }
     return outputs
 
@@ -929,3 +929,4 @@ def numpy2python(results_dict):
 
 def normalizeDistCutoff(cutoff):
     return (1 + np.tanh(cutoff)) / 2
+


### PR DESCRIPTION
--> commented out unused RL code

--> added standard dropout to all models

--> deleted unused LSTM

--> changed variance to std deviation throughout. (This should be double-checked in the future, can wait for now)

--> added uncertainty quantification via dropout to our proxy models (accompanying dropout and # dropout samples hyperparams)

--> added option for what to do with uncertainty estimation: raw, UCB, EI, and added respective functions

--> need to make double-sure whether u=-u in enumerate() option 'ei', also I really don't know why there are sigmoids all over the place - I may or may not be using the correctly given our use of standardization. Just going with it for now

--XX FYI - to evaluate the proxy model with fancy new aquisition functions, replace argument 'both' in proxy.evaluate() with 'fancy aquisition', which will return 3 variables: aquisition score, raw output a.k.a. 'energy', and the std deviation

--> updated gfn to get score directly from the proxy via proxy.evaluate(). Looking at it now, it's not clear to me that gflownet was actually properly set up for uncertainty sampling, since the proxy_val was always taken as the score? Anyway it appears to work but I was missing some configs still so didn't test.