### PR TITLE
Oracle upgrades, model state simplification

### DIFF
--- a/aptamers.py
+++ b/aptamers.py
@@ -62,19 +62,6 @@ class AptamerSeq:
         self.id = env_id
         self.n_actions = 0
         self.oracle = oracle_func
-        """    
-            {
-            "default": None,
-            "arbitrary_i": self.reward_arbitrary_i,
-            "linear": linearToy,
-            "innerprod": toyHamiltonian,
-            "potts": PottsEnergy,
-            "seqfold": seqfoldScore,
-            "nupack energy": lambda x: nupackScore(x, returnFunc="energy"),
-            "nupack pairs": lambda x: nupackScore(x, returnFunc="pairs"),
-            "nupack pins": lambda x: nupackScore(x, returnFunc="hairpins"),
-        }[self.func]
-        """
         if proxy:
             self.proxy = proxy
         else:

--- a/aptamers.py
+++ b/aptamers.py
@@ -2,11 +2,7 @@
 Classes to represent aptamers environments
 """
 import itertools
-
 import numpy as np
-
-# from oracles import PottsEnergy, linearToy, nupackScore, seqfoldScore, toyHamiltonian
-
 
 class AptamerSeq:
     """

--- a/aptamers.py
+++ b/aptamers.py
@@ -50,7 +50,7 @@ class AptamerSeq:
         debug=False,
         reward_beta=1,
         env_id=None,
-        oracleFunc=None,
+        oracle_func=None,
     ):
         self.max_seq_length = max_seq_length
         self.min_seq_length = min_seq_length
@@ -61,7 +61,7 @@ class AptamerSeq:
         self.done = False
         self.id = env_id
         self.n_actions = 0
-        self.oracle = oracleFunc
+        self.oracle = oracle_func
         """    
             {
             "default": None,

--- a/aptamers.py
+++ b/aptamers.py
@@ -5,7 +5,7 @@ import itertools
 
 import numpy as np
 
-from oracles import PottsEnergy, linearToy, nupackScore, seqfoldScore, toyHamiltonian
+#from oracles import PottsEnergy, linearToy, nupackScore, seqfoldScore, toyHamiltonian
 
 
 class AptamerSeq:
@@ -43,18 +43,18 @@ class AptamerSeq:
     """
 
     def __init__(
-        self,
-        max_seq_length=42,
-        min_seq_length=1,
-        nalphabet=4,
-        min_word_len=1,
-        max_word_len=1,
-        func="default",
-        proxy=None,
-        allow_backward=False,
-        debug=False,
-        reward_beta=1,
-        env_id=None,
+            self,
+            max_seq_length=42,
+            min_seq_length=1,
+            nalphabet=4,
+            min_word_len=1,
+            max_word_len=1,
+            proxy=None,
+            allow_backward=False,
+            debug=False,
+            reward_beta=1,
+            env_id=None,
+            oracleFunc=None,
     ):
         self.max_seq_length = max_seq_length
         self.min_seq_length = min_seq_length
@@ -65,8 +65,9 @@ class AptamerSeq:
         self.done = False
         self.id = env_id
         self.n_actions = 0
-        self.func = func
-        self.oracle = {
+        self.oracle = oracleFunc
+        '''    
+            {
             "default": None,
             "arbitrary_i": self.reward_arbitrary_i,
             "linear": linearToy,
@@ -77,6 +78,7 @@ class AptamerSeq:
             "nupack pairs": lambda x: nupackScore(x, returnFunc="pairs"),
             "nupack pins": lambda x: nupackScore(x, returnFunc="hairpins"),
         }[self.func]
+        '''
         if proxy:
             self.proxy = proxy
         else:
@@ -143,19 +145,15 @@ class AptamerSeq:
         """
         Prepares the output of an oracle for GFlowNet.
         """
-        if "pins" in self.func or "pairs" in self.func:
-            return np.exp(self.reward_beta * proxy_vals)
-        else:
-            return np.exp(-self.reward_beta * proxy_vals)
+
+        return np.exp(-self.reward_beta * proxy_vals)
 
     def reward2proxy(self, reward):
         """
         Converts a "GFlowNet reward" into energy or values as returned by an oracle.
         """
-        if "pins" in self.func or "pairs" in self.func:
-            return np.log(reward) / self.reward_beta
-        else:
-            return -np.log(reward) / self.reward_beta
+
+        return -np.log(reward) / self.reward_beta
 
     def seq2obs(self, seq=None):
         """

--- a/aptamers.py
+++ b/aptamers.py
@@ -5,7 +5,7 @@ import itertools
 
 import numpy as np
 
-#from oracles import PottsEnergy, linearToy, nupackScore, seqfoldScore, toyHamiltonian
+# from oracles import PottsEnergy, linearToy, nupackScore, seqfoldScore, toyHamiltonian
 
 
 class AptamerSeq:
@@ -43,18 +43,18 @@ class AptamerSeq:
     """
 
     def __init__(
-            self,
-            max_seq_length=42,
-            min_seq_length=1,
-            nalphabet=4,
-            min_word_len=1,
-            max_word_len=1,
-            proxy=None,
-            allow_backward=False,
-            debug=False,
-            reward_beta=1,
-            env_id=None,
-            oracleFunc=None,
+        self,
+        max_seq_length=42,
+        min_seq_length=1,
+        nalphabet=4,
+        min_word_len=1,
+        max_word_len=1,
+        proxy=None,
+        allow_backward=False,
+        debug=False,
+        reward_beta=1,
+        env_id=None,
+        oracleFunc=None,
     ):
         self.max_seq_length = max_seq_length
         self.min_seq_length = min_seq_length
@@ -66,7 +66,7 @@ class AptamerSeq:
         self.id = env_id
         self.n_actions = 0
         self.oracle = oracleFunc
-        '''    
+        """    
             {
             "default": None,
             "arbitrary_i": self.reward_arbitrary_i,
@@ -78,7 +78,7 @@ class AptamerSeq:
             "nupack pairs": lambda x: nupackScore(x, returnFunc="pairs"),
             "nupack pins": lambda x: nupackScore(x, returnFunc="hairpins"),
         }[self.func]
-        '''
+        """
         if proxy:
             self.proxy = proxy
         else:

--- a/config/ST1.yml
+++ b/config/ST1.yml
@@ -1,9 +1,9 @@
 # General
 test_mode: False
 debug: False
-run_num: 1501
-explicit_run_enumeration: True
-machine: cluster
+run_num: 0
+explicit_run_enumeration: False
+machine: local
 device: cpu
 workdir: null
 # Seeds
@@ -17,7 +17,7 @@ seeds:
 dataset:
   oracle: nupack energy
   nupack_energy_reweighting: False
-  nupack_target_motif: .....(((((.......))))).....
+  nupack_target_motif: .....(((((.......))))).....(((......(((((....)))))..)))
   type: toy
   init_length: 100
   dict_size: 4

--- a/config/ST1.yml
+++ b/config/ST1.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1501
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: random
+  num_random_samples: 10000
+  annealing_samples: 100
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st1
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: flowmatch #trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 40
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/ST2.yml
+++ b/config/ST2.yml
@@ -1,9 +1,9 @@
 # General
 test_mode: False
 debug: False
-run_num: 1502
-explicit_run_enumeration: True
-machine: cluster
+run_num: 0
+explicit_run_enumeration: False
+machine: local
 device: cpu
 workdir: null
 # Seeds
@@ -17,7 +17,7 @@ seeds:
 dataset:
   oracle: nupack energy
   nupack_energy_reweighting: False
-  nupack_target_motif: .....(((((.......))))).....
+  nupack_target_motif: .....(((((.......))))).....(((......(((((....)))))..)))
   type: toy
   init_length: 100
   dict_size: 4
@@ -29,7 +29,7 @@ al:
   mode: sampling only # sampling only or active learning
   sample_method: random
   num_random_samples: 10000
-  annealing_samples: 1000
+  annealing_samples: 200
   annealing_time: 100
   query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
   acquisition_function : null # only for 'fancy_acquisition'

--- a/config/ST2.yml
+++ b/config/ST2.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1502
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: random
+  num_random_samples: 10000
+  annealing_samples: 1000
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st2
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: flowmatch #trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 40
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/ST3.yml
+++ b/config/ST3.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1503
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: mcmc
+  num_random_samples: 10000
+  annealing_samples: 1000
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st3
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: flowmatch #trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 40
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/ST3.yml
+++ b/config/ST3.yml
@@ -1,9 +1,9 @@
 # General
 test_mode: False
 debug: False
-run_num: 1503
-explicit_run_enumeration: True
-machine: cluster
+run_num: 0
+explicit_run_enumeration: False
+machine: local
 device: cpu
 workdir: null
 # Seeds
@@ -17,7 +17,7 @@ seeds:
 dataset:
   oracle: nupack energy
   nupack_energy_reweighting: False
-  nupack_target_motif: .....(((((.......))))).....
+  nupack_target_motif: .....(((((.......))))).....(((......(((((....)))))..)))
   type: toy
   init_length: 100
   dict_size: 4
@@ -107,6 +107,6 @@ proxy:
 # MCMC
 mcmc:
   sampling_time: 5000
-  num_samplers: 40
+  num_samplers: 20
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/ST4.yml
+++ b/config/ST4.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1504
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: mcmc
+  num_random_samples: 10000
+  annealing_samples: 1000
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st4
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: flowmatch #trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 80
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/ST4.yml
+++ b/config/ST4.yml
@@ -1,9 +1,9 @@
 # General
 test_mode: False
 debug: False
-run_num: 1504
-explicit_run_enumeration: True
-machine: cluster
+run_num: 0
+explicit_run_enumeration: False
+machine: local
 device: cpu
 workdir: null
 # Seeds
@@ -17,7 +17,7 @@ seeds:
 dataset:
   oracle: nupack energy
   nupack_energy_reweighting: False
-  nupack_target_motif: .....(((((.......))))).....
+  nupack_target_motif: .....(((((.......))))).....(((......(((((....)))))..)))
   type: toy
   init_length: 100
   dict_size: 4
@@ -107,6 +107,6 @@ proxy:
 # MCMC
 mcmc:
   sampling_time: 5000
-  num_samplers: 80
+  num_samplers: 40
   stun_min_gamma: -3
   stun_max_gamma: 1

--- a/config/ST5.yml
+++ b/config/ST5.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1505
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: gflownet
+  num_random_samples: 10000
+  annealing_samples: 100
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st5
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: flowmatch #trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 40
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/ST6.yml
+++ b/config/ST6.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1506
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: gflownet
+  num_random_samples: 10000
+  annealing_samples: 100
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st6
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: flowmatch #trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: True
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 40
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/ST7.yml
+++ b/config/ST7.yml
@@ -1,0 +1,112 @@
+# General
+test_mode: False
+debug: False
+run_num: 1507
+explicit_run_enumeration: True
+machine: cluster
+device: cpu
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack energy
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 60
+# AL
+al:
+  mode: sampling only # sampling only or active learning
+  sample_method: gflownet
+  num_random_samples: 10000
+  annealing_samples: 1000
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 40
+  query_selection: argmin
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 50
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - pure_sampling_runs
+      - st1
+# Querier
+querier:
+  model_state_size: 10
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.000001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: trajectorybalance
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 10
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 4
+  n_iter: 20000
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    base: null
+    n: 1000
+    path: null
+    period: null
+    min_length: 1
+    pct_test: 0 #0.4
+    seed: 0
+  oracle:
+    period: 100
+    nsamples: 1000
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: mlp
+  ensemble_size: 1 # >1 for 'ensemble' uncertainty estimation only
+  width: 256 # 256
+  n_layers: 4 # 5
+  mbsize: 10
+  max_epochs: 500
+  history: 25
+  shuffle_dataset: True
+  uncertainty_estimation : dropout
+  dropout: 0.1
+  dropout_samples: 25 # only used if uncertainty estimation is 'dropout'
+# MCMC
+mcmc:
+  sampling_time: 5000
+  num_samplers: 40
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/mk_test_defaults.yml
+++ b/config/mk_test_defaults.yml
@@ -1,0 +1,105 @@
+# General
+test_mode: False
+debug: True
+run_num: 0
+explicit_run_enumeration: False
+machine: "local"
+device: "cpu"
+workdir: null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack open loop
+  nupack_energy_reweighting: True
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 40
+# AL
+al:
+  sample_method: random
+  num_random_samples: 10000
+  annealing_samples: 250
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 20
+  query_selection: "clustering"
+  minima_dist_cutoff: 0.05
+  energy_uncertainty_tradeoff: 0.1
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 100
+  large_model_evaluation: False
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - al_pipeline_work
+# Querier
+querier:
+  model_state_size: 25
+# GFlowNet
+gflownet:
+  device: cpu
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.0001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: trajectorybalance # flowmatch
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 100
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 2
+  n_iter: 500
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    path: null
+    period: null #200
+    pct_test: null #0.4
+  oracle:
+    period: 100
+    nsamples: 100
+    k: [1, 10, 100]
+# Proxy model
+proxy:
+  model_type: "mlp"
+  ensemble_size: 1
+  width: 256
+  n_layers: 4
+  mbsize: 10
+  max_epochs: 200
+  shuffle_dataset: True
+  uncertainty_estimation : "dropout"
+  dropout: 0.1
+  dropout_samples: 25
+# MCMC
+mcmc:
+  sampling_time: 100
+  num_samplers: 10
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/config/mk_test_defaults.yml
+++ b/config/mk_test_defaults.yml
@@ -15,7 +15,7 @@ seeds:
   toy_oracle: 0
 # Dataset
 dataset:
-  oracle: nupack open loop
+  oracle: nupack motif
   nupack_energy_reweighting: True
   nupack_target_motif: .....(((((.......))))).....
   type: toy
@@ -23,22 +23,22 @@ dataset:
   dict_size: 4
   variable_length: True
   min_length: 10
-  max_length: 40
+  max_length: 30
 # AL
 al:
   sample_method: random
   num_random_samples: 10000
-  annealing_samples: 250
+  annealing_samples: 50
   annealing_time: 100
   query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
   acquisition_function : null # only for 'fancy_acquisition'
-  n_iter: 20
-  query_selection: "clustering"
-  minima_dist_cutoff: 0.05
-  energy_uncertainty_tradeoff: 0.1
+  n_iter: 40
+  query_selection: "argmin"
+  minima_dist_cutoff: 0
+  energy_uncertainty_tradeoff: 0
   UCB_kappa: 0.1
   EI_percentile: 80
-  queries_per_iter: 100
+  queries_per_iter: 10
   large_model_evaluation: False
   comet:
     project: aptamer-al-mk
@@ -46,7 +46,7 @@ al:
       - al_pipeline_work
 # Querier
 querier:
-  model_state_size: 25
+  model_state_size: 10
 # GFlowNet
 gflownet:
   device: cpu
@@ -90,9 +90,10 @@ proxy:
   model_type: "mlp"
   ensemble_size: 1
   width: 256
-  n_layers: 4
+  n_layers: 5
   mbsize: 10
-  max_epochs: 200
+  max_epochs: 500
+  history: 200
   shuffle_dataset: True
   uncertainty_estimation : "dropout"
   dropout: 0.1

--- a/config/mk_test_defaults_gfn_only.yml
+++ b/config/mk_test_defaults_gfn_only.yml
@@ -1,0 +1,110 @@
+# General
+test_mode: False
+debug: True
+run_num: 0
+explicit_run_enumeration: False
+machine: "local"
+device: "cuda"
+workdir: gfn_test_28 #!!null
+# Seeds
+seeds:
+  sampler: 0
+  gflownet: 0
+  model: 0
+  dataset: 0
+  toy_oracle: 0
+# Dataset
+dataset:
+  oracle: nupack motif
+  nupack_energy_reweighting: False
+  nupack_target_motif: .....(((((.......))))).....
+  type: toy
+  init_length: 100
+  dict_size: 4
+  variable_length: True
+  min_length: 10
+  max_length: 40
+# AL
+al:
+  sample_method: gflownet
+  num_random_samples: 10000
+  annealing_samples: 25
+  annealing_time: 100
+  query_mode: energy # must be 'fancy_acquisition' for our new acquisition functions "EI" and "UCB"
+  acquisition_function : null # only for 'fancy_acquisition'
+  n_iter: 10
+  query_selection: "clustering"
+  minima_dist_cutoff: 0.1
+  energy_uncertainty_tradeoff: 0
+  UCB_kappa: 0.1
+  EI_percentile: 80
+  queries_per_iter: 100
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - al_pipeline_work
+# Querier
+querier:
+  model_state_size: 25
+# GFlowNet
+gflownet:
+  max_seq_length: 40 # should be aligned with 'dataset' above
+  min_seq_length: 10 # should be aligned with 'dataset' above
+  device: cuda
+  ckpt_period: 500
+  clip_grad_norm: 0.0
+  early_stopping: 0.0001
+  learning_rate: 0.001
+  momentum: 0.9
+  ema_alpha: 0.5
+  loss: trajectorybalance # flowmatch
+  lr_z_mult: 10
+  max_word_len: 1
+  min_word_len: 1
+  mbsize: 100
+  reload_ckpt: True
+  model_ckpt: model.pt
+  n_hid: 256
+  n_layers: 2
+  n_iter: 500
+  num_empirical_loss: 200000
+  opt: adam
+  pct_batch_empirical: 0.0
+  progress: 1
+  random_action_prob: 0.33
+  reward_beta_init: 0.05
+  reward_beta_mult: 1.25
+  reward_beta_period: 100
+  reward_max: 1000000
+  n_samples: 10000
+  annealing: False
+  test:
+    path: null
+    period: null #200
+    pct_test: null #0.4
+  oracle:
+    period: 100
+    nsamples: 100
+    k: [1, 10, 100]
+  comet:
+    project: aptamer-al-mk
+    tags:
+      - gflownet_testing
+# Proxy model
+proxy:
+  model_type: "mlp"
+  ensemble_size: 1
+  width: 256
+  n_layers: 4
+  mbsize: 10
+  max_epochs: 200
+  shuffle_dataset: True
+  uncertainty_estimation : "dropout"
+  dropout: 0.1
+  dropout_samples: 25
+# MCMC
+mcmc:
+  sampling_time: 100
+  num_samplers: 10
+  stun_min_gamma: -3
+  stun_max_gamma: 1

--- a/gflownet.py
+++ b/gflownet.py
@@ -71,7 +71,7 @@ def add_args(parser):
     )
     args2config.update({"rng_seed": ["seeds", "gflownet"]})
     # dataset
-    add_bool_arg(parser, "nupack_energy_reweighting", default=False)
+    parser = add_bool_arg(parser, "nupack_energy_reweighting", default=False)
     args2config.update(
         {"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]}
     )

--- a/gflownet.py
+++ b/gflownet.py
@@ -20,8 +20,8 @@ from torch.distributions.categorical import Categorical
 from tqdm import tqdm
 
 from aptamers import AptamerSeq
-from oracle import numbers2letters
-from utils import get_config, namespace2dict, numpy2python
+from oracle import numbers2letters, Oracle
+from utils import get_config, namespace2dict, numpy2python, add_bool_arg
 
 # Float and Long tensors
 _dev = [torch.device("cpu")]
@@ -41,7 +41,7 @@ def add_args(parser):
     parser.add_argument(
         "-y",
         "--yaml_config",
-        default=None,
+        default='config/mk_test_defaults_gfn_only.yml',
         type=str,
         help="YAML configuration file",
     )
@@ -70,6 +70,16 @@ def add_args(parser):
         help="Seed for random number generator",
     )
     args2config.update({"rng_seed": ["seeds", "gflownet"]})
+    # dataset
+    add_bool_arg(parser,'nupack_energy_reweighting',default=False)
+    args2config.update({"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]})
+    parser.add_argument(
+        "--nupack_target_motif",
+        type=str,
+        default=".....(((((.......))))).....",
+        help = "if using 'nupack motif' oracle, return value is the binary distance to this fold, must be <= max sequence length"
+    )
+    args2config.update({"nupack_target_motif": ["dataset", "nupack_target_motif"]})
     # Training hyperparameters
     parser.add_argument(
         "--loss", default="flowmatch", type=str, help="flowmatch | trajectorybalance/tb"
@@ -164,7 +174,7 @@ def add_args(parser):
     args2config.update({"func": ["gflownet", "func"]})
     parser.add_argument(
         "--max_seq_length",
-        default=42,
+        default=40,
         help="Maximum number of episodes; maximum sequence length",
         type=int,
     )
@@ -227,6 +237,14 @@ def add_args(parser):
     args2config.update({"no_comet": ["gflownet", "comet", "skip"]})
     parser.add_argument("--no_log_times", action="store_true")
     args2config.update({"no_log_times": ["gflownet", "no_log_times"]})
+    parser.add_argument(
+        "--n_samples",
+        type=int,
+        default=10000,
+        help="Sequences to sample",
+    )
+    args2config.update({"n_samples": ["gflownet", "n_samples"]})
+
     return parser, args2config
 
 
@@ -242,6 +260,7 @@ def set_device(dev):
 class GFlowNetAgent:
     def __init__(self, args, comet=None, proxy=None, al_iter=-1, data_path=None):
         # Misc
+        self.oracle = Oracle(args)
         self.rng = np.random.default_rng(args.seeds.gflownet)
         self.debug = args.debug
         self.device_torch = torch.device(args.gflownet.device)
@@ -302,11 +321,11 @@ class GFlowNetAgent:
             args.gflownet.nalphabet,
             args.gflownet.min_word_len,
             args.gflownet.max_word_len,
-            func=args.gflownet.func,
             proxy=proxy,
             allow_backward=False,
             debug=self.debug,
             reward_beta=self.reward_beta,
+            oracleFunc=self.oracle.score,
         )
         self.envs = [
             AptamerSeq(
@@ -315,11 +334,11 @@ class GFlowNetAgent:
                 args.gflownet.nalphabet,
                 args.gflownet.min_word_len,
                 args.gflownet.max_word_len,
-                func=args.gflownet.func,
                 proxy=proxy,
                 allow_backward=False,
                 debug=self.debug,
                 reward_beta=self.reward_beta,
+                oracleFunc = self.oracle.score,
             )
             for _ in range(args.gflownet.mbsize)
         ]
@@ -343,6 +362,7 @@ class GFlowNetAgent:
                 self.model_path = args.gflownet.model_ckpt
             if self.model_path.exists() and self.reload_ckpt:
                 self.model.load_state_dict(torch.load(self.model_path))
+                print("Reloaded GFN Model Checkpoint")
         else:
             self.model_path = None
         self.ckpt_period = args.gflownet.ckpt_period
@@ -402,9 +422,9 @@ class GFlowNetAgent:
                     ntest=args.gflownet.test.n,
                     min_length=args.gflownet.test.min_length,
                     max_length=args.gflownet.max_seq_length,
-                    seed=args.gflownet.test.seed,
-                    output_csv=args.gflownet.test.output,
-                )
+                    seed=args.gflownet.test.seed,)
+                    #output_csv=args.gflownet.test.output,
+                #)
         if self.df_test is not None:
             print("\nTest data")
             print(f"\tAverage score: {self.df_test[self.test_score].mean()}")
@@ -820,11 +840,8 @@ class GFlowNetAgent:
                     self.env.oracle,
                     get_uncertainties=False,
                 )
-                scores = oracle_dict["scores"]
-                if any([s in self.env.func for s in ["pins", "pairs"]]):
-                    scores_sorted = np.sort(scores)[::-1]
-                else:
-                    scores_sorted = np.sort(scores)
+                scores = oracle_dict["energies"]
+                scores_sorted = np.sort(scores)
                 dict_topk = {}
                 for k in self.oracle_k:
                     mean_topk = np.mean(scores_sorted[:k])
@@ -1293,7 +1310,7 @@ def np2df(test_path, score, al_init_length, al_queries_per_iter, pct_test, data_
     df = pd.DataFrame(
         {
             "letters": letters,
-            score: data_dict["scores"],
+            score: data_dict["energies"],
             "train": [False] * len(letters),
             "test": [False] * len(letters),
         }
@@ -1346,6 +1363,20 @@ def logq(traj_list, actions_list, model, env):
 def main(args):
     gflownet_agent = GFlowNetAgent(args)
     gflownet_agent.train()
+
+    # sample from the oracle, not from a proxy model
+    samples, times = gflownet_agent.sample(
+        args.gflownet.n_samples,
+        args.gflownet.max_seq_length,
+        args.gflownet.min_seq_length,
+        args.gflownet.nalphabet,
+        args.gflownet.min_word_len,
+        args.gflownet.max_word_len,
+        gflownet_agent.env.oracle,
+        mask_eos=True,
+        get_uncertainties=False
+    )
+
 
 
 if __name__ == "__main__":

--- a/gflownet.py
+++ b/gflownet.py
@@ -325,7 +325,7 @@ class GFlowNetAgent:
             allow_backward=False,
             debug=self.debug,
             reward_beta=self.reward_beta,
-            oracleFunc=self.oracle.score,
+            oracle_func=self.oracle.score,
         )
         self.envs = [
             AptamerSeq(
@@ -338,7 +338,7 @@ class GFlowNetAgent:
                 allow_backward=False,
                 debug=self.debug,
                 reward_beta=self.reward_beta,
-                oracleFunc = self.oracle.score,
+                oracle_func = self.oracle.score,
             )
             for _ in range(args.gflownet.mbsize)
         ]

--- a/gflownet.py
+++ b/gflownet.py
@@ -41,7 +41,7 @@ def add_args(parser):
     parser.add_argument(
         "-y",
         "--yaml_config",
-        default='config/mk_test_defaults_gfn_only.yml',
+        default="config/mk_test_defaults_gfn_only.yml",
         type=str,
         help="YAML configuration file",
     )
@@ -71,13 +71,15 @@ def add_args(parser):
     )
     args2config.update({"rng_seed": ["seeds", "gflownet"]})
     # dataset
-    add_bool_arg(parser,'nupack_energy_reweighting',default=False)
-    args2config.update({"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]})
+    add_bool_arg(parser, "nupack_energy_reweighting", default=False)
+    args2config.update(
+        {"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]}
+    )
     parser.add_argument(
         "--nupack_target_motif",
         type=str,
         default=".....(((((.......))))).....",
-        help = "if using 'nupack motif' oracle, return value is the binary distance to this fold, must be <= max sequence length"
+        help="if using 'nupack motif' oracle, return value is the binary distance to this fold, must be <= max sequence length",
     )
     args2config.update({"nupack_target_motif": ["dataset", "nupack_target_motif"]})
     # Training hyperparameters
@@ -338,7 +340,7 @@ class GFlowNetAgent:
                 allow_backward=False,
                 debug=self.debug,
                 reward_beta=self.reward_beta,
-                oracle_func = self.oracle.score,
+                oracle_func=self.oracle.score,
             )
             for _ in range(args.gflownet.mbsize)
         ]
@@ -422,9 +424,10 @@ class GFlowNetAgent:
                     ntest=args.gflownet.test.n,
                     min_length=args.gflownet.test.min_length,
                     max_length=args.gflownet.max_seq_length,
-                    seed=args.gflownet.test.seed,)
-                    #output_csv=args.gflownet.test.output,
-                #)
+                    seed=args.gflownet.test.seed,
+                )
+                # output_csv=args.gflownet.test.output,
+                # )
         if self.df_test is not None:
             print("\nTest data")
             print(f"\tAverage score: {self.df_test[self.test_score].mean()}")
@@ -846,7 +849,7 @@ class GFlowNetAgent:
                 for k in self.oracle_k:
                     mean_topk = np.mean(scores_sorted[:k])
                     dict_topk.update(
-                            {"oracle_mean_top{}{}".format(k, self.al_iter): mean_topk}
+                        {"oracle_mean_top{}{}".format(k, self.al_iter): mean_topk}
                     )
                     if self.comet:
                         self.comet.log_metrics(dict_topk)
@@ -997,8 +1000,10 @@ class GFlowNetAgent:
         batch = np.asarray(batch)
 
         if get_uncertainties:
-            if self.query_function == 'fancy_acquisition':
-                scores, proxy_vals, uncertainties = env.proxy(batch, "fancy_acquisition")
+            if self.query_function == "fancy_acquisition":
+                scores, proxy_vals, uncertainties = env.proxy(
+                    batch, "fancy_acquisition"
+                )
             else:
                 proxy_vals, uncertainties = env.proxy(batch, "Both")
                 scores = proxy_vals
@@ -1374,9 +1379,8 @@ def main(args):
         args.gflownet.max_word_len,
         gflownet_agent.env.oracle,
         mask_eos=True,
-        get_uncertainties=False
+        get_uncertainties=False,
     )
-
 
 
 if __name__ == "__main__":

--- a/gflownet.py
+++ b/gflownet.py
@@ -425,9 +425,8 @@ class GFlowNetAgent:
                     min_length=args.gflownet.test.min_length,
                     max_length=args.gflownet.max_seq_length,
                     seed=args.gflownet.test.seed,
+                    output_csv=args.gflownet.test.output,
                 )
-                # output_csv=args.gflownet.test.output,
-                # )
         if self.df_test is not None:
             print("\nTest data")
             print(f"\tAverage score: {self.df_test[self.test_score].mean()}")

--- a/gflownet.py
+++ b/gflownet.py
@@ -41,7 +41,7 @@ def add_args(parser):
     parser.add_argument(
         "-y",
         "--yaml_config",
-        default="config/mk_test_defaults_gfn_only.yml",
+        default=None,
         type=str,
         help="YAML configuration file",
     )

--- a/main.py
+++ b/main.py
@@ -575,8 +575,6 @@ def process_config(config):
         ]
         config.dataset.dict_size = 4
     # GFlowNet
-    config.gflownet.post_annealing_samples = config.al.annealing_samples
-    config.gflownet.post_annealing_time = config.al.annealing_time
     config.gflownet.max_seq_length = config.dataset.max_length
     config.gflownet.min_seq_length = config.dataset.min_length
     config.gflownet.nalphabet = config.dataset.dict_size

--- a/main.py
+++ b/main.py
@@ -451,18 +451,18 @@ def add_args(parser):
     args2config.update({"gflownet_test_period": ["gflownet", "test", "period"]})
     parser.add_argument("--gflownet_pct_test", default=500, type=int)
     args2config.update({"gflownet_pct_test": ["gflownet", "test", "pct_test"]})
-    parser.add_argument("--oracle_period", default=500, type=int)
-    args2config.update({"oracle_period": ["gflownet", "oracle", "period"]})
-    parser.add_argument("--oracle_nsamples", default=500, type=int)
-    args2config.update({"oracle_nsamples": ["gflownet", "oracle", "nsamples"]})
+    parser.add_argument("--gflownet_oracle_period", default=500, type=int)
+    args2config.update({"gflownet_oracle_period": ["gflownet", "oracle", "period"]})
+    parser.add_argument("--gflownet_oracle_nsamples", default=500, type=int)
+    args2config.update({"gflownet_oracle_nsamples": ["gflownet", "oracle", "nsamples"]})
     parser.add_argument(
-        "--oracle_k",
+        "--gflownet_oracle_k",
         default=[1, 10, 100],
         nargs="*",
         type=int,
         help="List of K, for Top-K",
     )
-    args2config.update({"oracle_k": ["gflownet", "oracle", "k"]})
+    args2config.update({"gflownet_oracle_k": ["gflownet", "oracle", "k"]})
     # Proxy model
     parser.add_argument(
         "--proxy_model_type",

--- a/main.py
+++ b/main.py
@@ -496,6 +496,8 @@ def add_args(parser):
     args2config.update({"proxy_training_batch_size": ["proxy", "mbsize"]})
     parser.add_argument("--proxy_max_epochs", type=int, default=200)
     args2config.update({"proxy_max_epochs": ["proxy", "max_epochs"]})
+    parser.add_argument("--proxy_history", type=int, default=20)
+    args2config.update({"proxy_history": ["proxy", "history"]})
     parser.add_argument(
         "--proxy_no_shuffle_dataset",
         dest="proxy_shuffle_dataset",

--- a/main.py
+++ b/main.py
@@ -249,8 +249,8 @@ def add_args(parser):
     parser.add_argument(
         "--mode",
         type=str,
-        default="training",
-        help="'training'  'evaluation' 'initialize' - only training currently useful",
+        default="active learning",
+        help="'active learning'  'sampling only' ",
     )
     args2config.update({"mode": ["al", "mode"]})
     parser = add_bool_arg(parser,'large_model_evaluation',default=False) # do a large test dataset run to evaluate proxy performance mid-run
@@ -599,13 +599,12 @@ if __name__ == "__main__":
     al = activeLearner.ActiveLearning(config)
     if config.al.mode == "initalize":
         printRecord("Initialized!")
-    elif config.al.mode == "training":
+    elif config.al.mode == "active learning":
         al.runPipeline()
     elif config.al.mode == "deploy":
         al.runPipeline()
+    elif config.al.mode == 'sampling only':
+        sampleDict = al.runPureSampler()
     elif config.al.mode == "test_rl":
         al.agent.train_from_file()
-    elif config.al.mode == "evaluation":
-        ValueError(
-            "No function for this! Write a function to load torch models and evaluate inputs."
-        )
+

--- a/main.py
+++ b/main.py
@@ -108,13 +108,15 @@ def add_args(parser):
         "--dataset", type=str, default="linear"
     )  # 'linear' 'potts' 'nupack energy' 'nupack pairs' 'nupack pins' 'nupack open loop' 'nupack motif' #set motif in oracles.py
     args2config.update({"dataset": ["dataset", "oracle"]})
-    parser = add_bool_arg(parser,'nupack_energy_reweighting',default=False)
-    args2config.update({"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]})
+    parser = add_bool_arg(parser, "nupack_energy_reweighting", default=False)
+    args2config.update(
+        {"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]}
+    )
     parser.add_argument(
         "--nupack_target_motif",
         type=str,
         default=".....(((((.......))))).....",
-        help = "if using 'nupack motif' oracle, return value is the binary distance to this fold, must be <= max sequence length"
+        help="if using 'nupack motif' oracle, return value is the binary distance to this fold, must be <= max sequence length",
     )
     args2config.update({"nupack_target_motif": ["dataset", "nupack_target_motif"]})
     parser.add_argument(
@@ -178,18 +180,14 @@ def add_args(parser):
         default=1000,
         help="number of init configs for post sample annealing",
     )
-    args2config.update(
-        {"annealing_samples": ["al", "annealing_samples"]}
-    )
+    args2config.update({"annealing_samples": ["al", "annealing_samples"]})
     parser.add_argument(
         "--annealing_time",
         type=int,
         default=1000,
         help="number MCMC steps for post sample annealing",
     )
-    args2config.update(
-        {"annealing_time": ["al", "annealing_time"]}
-    )
+    args2config.update({"annealing_time": ["al", "annealing_time"]})
     parser.add_argument(
         "--query_mode",
         type=str,
@@ -253,7 +251,9 @@ def add_args(parser):
         help="'active learning'  'sampling only' ",
     )
     args2config.update({"mode": ["al", "mode"]})
-    parser = add_bool_arg(parser,'large_model_evaluation',default=False) # do a large test dataset run to evaluate proxy performance mid-run
+    parser = add_bool_arg(
+        parser, "large_model_evaluation", default=False
+    )  # do a large test dataset run to evaluate proxy performance mid-run
     args2config.update({"large_model_evaluation": ["al", "large_model_evaluation"]})
     parser.add_argument("--q_network_width", type=int, default=10)
     args2config.update({"q_network_width": ["al", "q_network_width"]})
@@ -506,11 +506,23 @@ def add_args(parser):
         help="give each model in the ensemble a uniquely shuffled dataset",
     )
     args2config.update({"proxy_shuffle_dataset": ["proxy", "shuffle_dataset"]})
-    parser.add_argument("--proxy_uncertainty_estimation", type=str, default="dropout", help="dropout or ensemble")
-    args2config.update({"proxy_uncertainty_estimation": ["proxy", "uncertainty_estimation"]})
-    parser.add_argument("--proxy_dropout", type=float, default = 0.1)
+    parser.add_argument(
+        "--proxy_uncertainty_estimation",
+        type=str,
+        default="dropout",
+        help="dropout or ensemble",
+    )
+    args2config.update(
+        {"proxy_uncertainty_estimation": ["proxy", "uncertainty_estimation"]}
+    )
+    parser.add_argument("--proxy_dropout", type=float, default=0.1)
     args2config.update({"proxy_dropout": ["proxy", "dropout"]})
-    parser.add_argument("--proxy_dropout_samples", type=int, default = 25, help="number of times to resample via stochastic dropout")
+    parser.add_argument(
+        "--proxy_dropout_samples",
+        type=int,
+        default=25,
+        help="number of times to resample via stochastic dropout",
+    )
     args2config.update({"proxy_dropout_samples": ["proxy", "dropout_samples"]})
     # MCMC
     parser.add_argument(
@@ -603,8 +615,7 @@ if __name__ == "__main__":
         al.runPipeline()
     elif config.al.mode == "deploy":
         al.runPipeline()
-    elif config.al.mode == 'sampling only':
+    elif config.al.mode == "sampling only":
         sampleDict = al.runPureSampler()
     elif config.al.mode == "test_rl":
         al.agent.train_from_file()
-

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ def add_args(parser):
         "--dataset", type=str, default="linear"
     )  # 'linear' 'potts' 'nupack energy' 'nupack pairs' 'nupack pins' 'nupack open loop' 'nupack motif' #set motif in oracles.py
     args2config.update({"dataset": ["dataset", "oracle"]})
-    add_bool_arg(parser,'nupack_energy_reweighting',default=False)
+    parser = add_bool_arg(parser,'nupack_energy_reweighting',default=False)
     args2config.update({"nupack_energy_reweighting": ["dataset", "nupack_energy_reweighting"]})
     parser.add_argument(
         "--nupack_target_motif",
@@ -253,7 +253,7 @@ def add_args(parser):
         help="'training'  'evaluation' 'initialize' - only training currently useful",
     )
     args2config.update({"mode": ["al", "mode"]})
-    add_bool_arg(parser,'large_model_evaluation',default=False) # do a large test dataset run to evaluate proxy performance mid-run
+    parser = add_bool_arg(parser,'large_model_evaluation',default=False) # do a large test dataset run to evaluate proxy performance mid-run
     args2config.update({"large_model_evaluation": ["al", "large_model_evaluation"]})
     parser.add_argument("--q_network_width", type=int, default=10)
     args2config.update({"q_network_width": ["al", "q_network_width"]})

--- a/models.py
+++ b/models.py
@@ -30,7 +30,7 @@ class modelNet():
     def __init__(self, config, ensembleIndex):
         self.config = config
         self.ensembleIndex = ensembleIndex
-        self.config.history = min(20, self.config.proxy.max_epochs) # length of past to check
+        self.config.history = min(self.config.proxy.history, self.config.proxy.max_epochs) # length of past to check
         torch.random.manual_seed(int(config.seeds.model + ensembleIndex))
         self.initModel()
 
@@ -726,7 +726,7 @@ class MLP(nn.Module):
 
         self.output_layers = []
         for i in range(self.tasks):
-            self.output_layers.append(nn.Linear(self.filters, 1))
+            self.output_layers.append(nn.Linear(self.filters, 1, bias=False))
         self.output_layers = nn.ModuleList(self.output_layers)
 
         # build hidden layers

--- a/models.py
+++ b/models.py
@@ -241,15 +241,15 @@ class modelNet():
         if self.config.proxy.uncertainty_estimation == "ensemble":
             self.model.train(False)
             with torch.no_grad():  # we won't need gradients! no training just testing
-                outputs = self.model(Data)
-                mean = torch.mean(outputs,dim=1).cpu().detach().numpy()
-                std = torch.std(outputs,dim=1).cpu().detach().numpy()
+                outputs = self.model(Data).cpu().detach().numpy()
+                mean = torch.mean(outputs,dim=1)
+                std = torch.std(outputs,dim=1)
         elif self.config.proxy.uncertainty_estimation == "dropout":
             self.model.train(True) # need this to be true to activate dropout
             with torch.no_grad():
-                outputs = torch.hstack([self.model(Data) for _ in range(self.config.proxy.dropout_samples)])
-            mean = torch.mean(outputs, dim=1).cpu().detach().numpy()
-            std = torch.std(outputs, dim=1).cpu().detach().numpy()
+                outputs = torch.hstack([self.model(Data) for _ in range(self.config.proxy.dropout_samples)]).cpu().detach().numpy()
+            mean = torch.mean(outputs, dim=1)
+            std = torch.std(outputs, dim=1)
         else:
             print("No uncertainty estimator called {}".format(self.config.proxy.uncertainty_estimation))
             sys.exit()

--- a/querier.py
+++ b/querier.py
@@ -160,7 +160,10 @@ class Querier():
 
         elif method.lower() == "random":
             t0 = time.time()
-            samples = generateRandomSamples(self.config.al.num_random_samples, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length, oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
+            samples = generateRandomSamples(self.config.al.num_random_samples, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size,
+                                            variableLength = self.config.dataset.variable_length,
+                                            oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy',
+                                            seed = self.config.seeds.sampler)
             if self.config.al.query_mode == 'fancy_acquisition':
                 scores, energies, std_dev = model.evaluate(samples,output="fancy_acquisition")
             else:
@@ -207,7 +210,7 @@ class Querier():
         initConfigs = initConfigs[0:self.config.al.annealing_samples]
 
         annealer = Sampler(self.config, 1, scoreFunction, gammas=np.arange(len(initConfigs)))  # the gamma is a dummy, and will not be used (this is not STUN MC)
-        annealedOutputs = annealer.postSampleAnnealing(initConfigs, model)
+        annealedOutputs = annealer.postSampleAnnealing(initConfigs, model, seed = self.config.seeds.sampler)
 
         filteredOutputs = filterOutputs(outputs, additionalEntries = annealedOutputs)
 

--- a/querier.py
+++ b/querier.py
@@ -204,13 +204,13 @@ class Querier():
         return outputs
 
 
-    def doAnnealing(self, scoreFunction, model, outputs):
+    def doAnnealing(self, scoreFunction, model, outputs, useOracle=False):
         t0 = time.time()
         initConfigs = outputs['samples'][np.argsort(outputs['scores'])]
         initConfigs = initConfigs[0:self.config.al.annealing_samples]
 
         annealer = Sampler(self.config, 1, scoreFunction, gammas=np.arange(len(initConfigs)))  # the gamma is a dummy, and will not be used (this is not STUN MC)
-        annealedOutputs = annealer.postSampleAnnealing(initConfigs, model, seed = self.config.seeds.sampler)
+        annealedOutputs = annealer.postSampleAnnealing(initConfigs, model, useOracle=useOracle, seed = self.config.seeds.sampler)
 
         filteredOutputs = filterOutputs(outputs, additionalEntries = annealedOutputs)
 

--- a/querier.py
+++ b/querier.py
@@ -23,7 +23,7 @@ class Querier():
         if self.config.al.query_mode == 'learned':
             pass
 
-    def buildQuery(self, model, statusDict, energySampleDict, action = None, comet=None,):
+    def buildQuery(self, model, statusDict, action = None, comet=None,):
         """
         select the samples which will be sent to the oracle for scoring
         if we are dynamically updating hyperparameters, take an action
@@ -42,23 +42,12 @@ class Querier():
             query = generateRandomSamples(nQueries, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length, oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
 
         else:
-            #if self.config.al.query_mode == 'learned': # we aren't doing this anymore
-            #    self.qModel.updateModelState(statusDict, model)
-            #    self.sampleDict = self.sampleForQuery(self.qModel, statusDict['iter'])
 
-            #else:
-            if True:
-                '''
-                query samples with best good scores, according to our model and a scoring function
-                '''
+            '''
+            query samples with best good scores, according to our model and a scoring function
+            '''
 
-                # generate candidates
-                #MK when up update model state calculation, it should be updated here as well
-                if (self.config.al.query_mode == 'energy') and (self.config.al.sample_method == 'mcmc'): # we already do energy based sampling with mcmc to generate the model state
-                    self.sampleDict = energySampleDict
-                else:
-                    self.sampleDict = self.sampleForQuery(model, statusDict['iter'])
-
+            self.sampleDict = self.sampleForQuery(model, statusDict['iter'])
             samples = self.sampleDict['samples']
             scores = self.sampleDict['scores']
             uncertainties = self.sampleDict['uncertainties']
@@ -104,12 +93,11 @@ class Querier():
             samples = samples[bestInds]
         elif self.config.al.query_selection == 'argmin':
             # just take the bottom x scores
-            if any([s in self.config.dataset.oracle for s in ["pins", "pairs"]]):
-                # TODO: a similar operation should be done for the other query
-                # selection options
-                samples = samples[np.argsort(scores)[::-1]]
-            else:
-                samples = samples[np.argsort(scores)]
+            samples = samples[np.argsort(scores)]
+
+        if len(samples) < nQueries:
+            missing_samples = nQueries - len(samples)
+            printRecord("Querier did not produce enough samples, adding {} random entries, consider adjusting query size and/or cutoff".format(missing_samples))
 
         while len(samples) < nQueries:  # if we don't have enough samples from samplers, add random ones to pad out the query
             randomSamples = generateRandomSamples(1000, [self.config.dataset.min_length, self.config.dataset.max_length], self.config.dataset.dict_size, variableLength=self.config.dataset.variable_length,
@@ -125,18 +113,24 @@ class Querier():
         automatically filter any duplicates within the sample and the existing dataset
         :return:
         '''
+        # get score function by which we identify 'good' samples to send to oracle
+        scoreFunction = self.getScoreFunction()
+
+        # do a single sampling run
+        sampleDict = self.runSampling(model, scoreFunction = scoreFunction, al_iter = iterNum)
+
+        return sampleDict # return information on samples collected during on the run
+
+
+    def getScoreFunction(self):
         if self.config.al.query_mode == 'energy':
             scoreFunction = [1, 0]  # weighting between score and uncertainty - look for minimum score
         elif self.config.al.query_mode == 'uncertainty':
             scoreFunction = [0, 1]  # look for maximum uncertainty
-        elif self.config.al.query_mode == 'heuristic':
+        elif (self.config.al.query_mode == 'heuristic') or (self.config.al.query_mode == 'learned'):
             c1 = 0.5 - self.config.al.energy_uncertainty_tradeoff / 2
             c2 = 0.5 + self.config.al.energy_uncertainty_tradeoff / 2
-            scoreFunction = [c1, c2]  # put in user specified values (or functions) here
-        elif self.config.al.query_mode == 'learned':
-            c1 = 0.5 - self.config.al.energy_uncertainty_tradeoff / 2
-            c2 = 0.5 + self.config.al.energy_uncertainty_tradeoff / 2
-            scoreFunction = [c1, c2]  # put in user specified values (or functions) here
+            scoreFunction = [c1, c2]
         elif self.config.al.query_mode == 'fancy_acquisition':
             c1 = 1
             c2 = 1
@@ -144,12 +138,9 @@ class Querier():
         else:
             raise ValueError(self.config.al.query_mode + 'is not a valid query function!')
 
-        # do a single sampling run
-        sampleDict = self.runSampling(model, scoreFunction, iterNum)
+        return scoreFunction
 
-        return sampleDict
-
-    def runSampling(self, model, scoreFunction, seedInd, useOracle=False, method_overwrite = False):
+    def runSampling(self, model, scoreFunction = (1, 0), al_iter = 0, useOracle=False, method_overwrite = False):
         """
         run MCMC or GFlowNet sampling
         :return:
@@ -160,15 +151,21 @@ class Querier():
             method = method_overwrite
 
         if method.lower() == "mcmc":
+            t0 = time.time()
             gammas = np.logspace(self.config.mcmc.stun_min_gamma, self.config.mcmc.stun_max_gamma, self.config.mcmc.num_samplers)
-            self.mcmcSampler = Sampler(self.config, seedInd, scoreFunction, gammas)
-            samples = self.mcmcSampler.sample(model, useOracle=useOracle)
-            outputs = samples2dict(samples)
+            self.mcmcSampler = Sampler(self.config, al_iter, scoreFunction, gammas)
+            outputs = self.mcmcSampler.sample(model, useOracle=useOracle)
+            outputs = filterOutputs(outputs)
+            printRecord('MCMC sampling took {} seconds'.format(int(time.time()-t0)))
 
         elif method.lower() == "random":
-            samples = generateRandomSamples(10000, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length, oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
-            energies, std_dev = model.evaluate(samples,output="Both")
-            scores = energies * scoreFunction[0] - scoreFunction[1] * np.asarray(std_dev)
+            t0 = time.time()
+            samples = generateRandomSamples(self.config.al.num_random_samples, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length, oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
+            if self.config.al.query_mode == 'fancy_acquisition':
+                scores, energies, std_dev = model.evaluate(samples,output="fancy_acquisition")
+            else:
+                energies, std_dev = model.evaluate(samples,output="Both")
+                scores = energies * scoreFunction[0] - scoreFunction[1] * np.asarray(std_dev)
             outputs = {
                 'samples': samples,
                 'energies': energies,
@@ -176,24 +173,23 @@ class Querier():
                 'scores':scores
             }
             outputs = self.doAnnealing(scoreFunction, model, outputs)
+            printRecord('Random sampling and annealing took {} seconds'.format(int(time.time()-t0)))
 
         elif method.lower() == "gflownet":
             gflownet = GFlowNetAgent(self.config, comet = self.comet, proxy=model.raw,
-                    al_iter=seedInd, data_path='datasets/' + self.config.dataset.oracle + '.npy')
+                                     al_iter=al_iter, data_path='datasets/' + self.config.dataset.oracle + '.npy')
 
             t0 = time.time()
             gflownet.train()
-            tf = time.time()
-            printRecord('Training GFlowNet took {} seconds'.format(int(tf-t0)))
+            printRecord('Training GFlowNet took {} seconds'.format(int(time.time()-t0)))
             t0 = time.time()
             outputs, times = gflownet.sample(
-                    self.config.gflownet.n_samples, self.config.dataset.max_length,
-                    self.config.dataset.min_length, self.config.dataset.dict_size, 
-                    self.config.gflownet.min_word_len, 
-                    self.config.gflownet.max_word_len, model.evaluate
+                self.config.gflownet.n_samples, self.config.dataset.max_length,
+                self.config.dataset.min_length, self.config.dataset.dict_size,
+                self.config.gflownet.min_word_len,
+                self.config.gflownet.max_word_len, model.evaluate
             )
-            tf = time.time()
-            printRecord('Sampling {} samples from GFlowNet took {} seconds'.format(self.config.gflownet.n_samples, int(tf-t0)))
+            printRecord('Sampling {} samples from GFlowNet took {} seconds'.format(self.config.gflownet.n_samples, int(time.time()-t0)))
             outputs = filterOutputs(outputs)
 
             if self.config.gflownet.annealing:
@@ -208,16 +204,15 @@ class Querier():
     def doAnnealing(self, scoreFunction, model, outputs):
         t0 = time.time()
         initConfigs = outputs['samples'][np.argsort(outputs['scores'])]
-        initConfigs = initConfigs[0:self.config.gflownet.post_annealing_samples]
+        initConfigs = initConfigs[0:self.config.al.annealing_samples]
 
-        annealer = Sampler(self.config, 1, scoreFunction, gammas=np.arange(len(initConfigs)))  # the gamma is a dummy
+        annealer = Sampler(self.config, 1, scoreFunction, gammas=np.arange(len(initConfigs)))  # the gamma is a dummy, and will not be used (this is not STUN MC)
         annealedOutputs = annealer.postSampleAnnealing(initConfigs, model)
 
         filteredOutputs = filterOutputs(outputs, additionalEntries = annealedOutputs)
-        tf = time.time()
 
         nAddedSamples = int(len(filteredOutputs['samples']) - len(outputs['samples']))
 
-        printRecord('Post-sample annealing added {} samples in {} seconds'.format(nAddedSamples, int(tf-t0)))
+        printRecord('Post-sample annealing added {} samples in {} seconds'.format(nAddedSamples, int(time.time()-t0)))
 
         return filteredOutputs

--- a/querier.py
+++ b/querier.py
@@ -39,7 +39,9 @@ class Querier():
             '''
             generate query randomly
             '''
-            query = generateRandomSamples(nQueries, [self.config.dataset.min_length,self.config.dataset.max_length], self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length, oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
+            query = generateRandomSamples(nQueries, [self.config.dataset.min_length,self.config.dataset.max_length],
+                                          self.config.dataset.dict_size, variableLength = self.config.dataset.variable_length,
+                                          oldDatasetPath = 'datasets/' + self.config.dataset.oracle + '.npy')
 
         else:
 
@@ -81,6 +83,15 @@ class Querier():
 
     def constructQuery(self, samples, scores, uncertainties, nQueries):
         # create batch from candidates
+
+        # for memory purposes, we have to cap the total number of samples considered
+        maxLen = 10000
+        if len(samples) > maxLen:
+            bestInds = np.argsort(scores)[:maxLen]
+            scores = scores[bestInds]
+            samples = samples[bestInds]
+            uncertainties = uncertainties[bestInds]
+
         if self.config.al.query_selection == 'clustering':
             # agglomerative clustering
             clusters, clusterScores, clusterVars = doAgglomerativeClustering(samples, scores, uncertainties, self.config.dataset.dict_size, cutoff=normalizeDistCutoff(self.config.al.minima_dist_cutoff))

--- a/sampler.py
+++ b/sampler.py
@@ -116,6 +116,7 @@ class Sampler:
         self.new_optima_energies = [[] for i in range(self.nruns)] # new minima
         self.new_optima_samples = [[] for i in range(self.nruns)] # new minima
 
+
         # set initial values
         self.E0 = scores[1]  # initialize the 'best score' value
         self.absMin = np.amin(self.E0)
@@ -129,6 +130,7 @@ class Sampler:
             self.new_optima_energies[i].append(energy[1][i])
             self.new_optima_scores[i].append(scores[1][i])
             self.new_optima_inds[i].append(0)
+
 
 
     def initRecs(self):
@@ -397,7 +399,7 @@ class Sampler:
 
             # if we haven't found a new minimum in a long time, randomize input and do a temperature boost
             if (self.iter - self.resetInd[i]) > 1e3:  # within xx of the last reset
-                if (self.iter - self.optimalInds[i][-1]) > 1e3: # haven't seen a new near-minimum in xx steps
+                if (self.iter - self.new_optima_inds[i][-1]) > 1e3: # haven't seen a new near-minimum in xx steps
                     self.resetInd[i] = self.iter
                     self.resetConfig(i)  # re-randomize
                     self.temperature[i] = self.temp0 # boost temperature

--- a/sampler.py
+++ b/sampler.py
@@ -201,7 +201,7 @@ class Sampler:
         printRecord("{} samples were recorded on this run".format(len(np.concatenate(self.all_samples))))
 
 
-    def postSampleAnnealing(self, initConfigs, model, useOracle=False):
+    def postSampleAnnealing(self, initConfigs, model, useOracle=False, seed = 0):
         '''
         run a sampling run with the following characteristics
         - low temperature so that we quickly crash to global minimum
@@ -209,6 +209,7 @@ class Sampler:
         - instead of many parallel stun functions, many parallel initial configurations
         - return final configurations for each run as 'annealed samples'
         '''
+        np.random.seed(seed)
         self.config_main.STUN = 0
         self.nruns = len(initConfigs)
         self.temp0 = 0.01 # initial temperature for sampling runs - start low and shrink

--- a/sampler.py
+++ b/sampler.py
@@ -104,10 +104,10 @@ class Sampler:
         :return:
         """
         # trajectory
-        self.all_scores = [[] for i in range(self.nruns)] # record optima of the score function
-        self.all_energies = [[] for i in range(self.nruns)]  # record energies near the optima
-        self.all_uncertainties = [[] for i in range(self.nruns)]  # record of uncertainty at the optima
-        self.all_samples = [[] for i in range(self.nruns)]
+        self.all_scores = np.zeros((self.run_iters, self.nruns)) # record optima of the score function
+        self.all_energies = np.zeros_like(self.all_scores)  # record energies near the optima
+        self.all_uncertainties = np.zeros_like(self.all_scores)  # record of uncertainty at the optima
+        self.all_samples = np.zeros((self.run_iters, self.nruns, self.config_main.dataset.max_length))
 
         # optima
         self.new_optima_inds = [[] for i in range(self.nruns)]
@@ -119,11 +119,12 @@ class Sampler:
         # set initial values
         self.E0 = scores[1]  # initialize the 'best score' value
         self.absMin = np.amin(self.E0)
+        self.all_scores[0] = scores[1]
+        self.all_energies[0] = energy[1]
+        self.all_uncertainties[0] = std_dev[1]
+        self.all_samples[0] = self.config
+
         for i in range(self.nruns):
-            self.all_scores[i].append(scores[1][i])
-            self.all_energies[i].append(energy[1][i])
-            self.all_uncertainties[i].append(std_dev[1][i])
-            self.all_samples[i].append(self.config[i])
             self.new_optima_samples[i].append(self.config[i])
             self.new_optima_energies[i].append(energy[1][i])
             self.new_optima_scores[i].append(scores[1][i])
@@ -184,12 +185,12 @@ class Sampler:
         self.resampleRandints()
 
         if nIters is None:
-            run_iters = self.config_main.mcmc.sampling_time
+            self.run_iters = self.config_main.mcmc.sampling_time
         else:
-            run_iters = nIters
+            self.run_iters = nIters
 
 
-        for self.iter in tqdm.tqdm(range(run_iters)):  # sample for a certain number of iterations
+        for self.iter in tqdm.tqdm(range(self.run_iters)):  # sample for a certain number of iterations
             self.iterate(model, useOracle)  # try a monte-carlo step!
 
             if (self.iter % self.deltaIter == 0) and (self.iter > 0):  # every N iterations do some reporting / updating
@@ -215,10 +216,11 @@ class Sampler:
         self.temp0 = 0.01 # initial temperature for sampling runs - start low and shrink
         self.temperature = [self.temp0 for _ in range(self.nruns)]
         self.config = initConfigs # manually overwrite configs
+        self.run_iters = self.config_main.al.annealing_time
 
         self.initConvergenceStats()
         self.resampleRandints()
-        for self.iter in tqdm.tqdm(range(self.config_main.al.annealing_time)):
+        for self.iter in tqdm.tqdm(range(self.run_iters)):
             self.iterate(model, useOracle)
 
             self.temperature = [temperature * 0.99 for temperature in self.temperature] # cut temperature at every time step
@@ -226,7 +228,7 @@ class Sampler:
             if self.iter % self.randintsResampleAt == 0: # periodically resample random numbers
                 self.resampleRandints()
 
-        evals = self.getScores(self.config, self.config, model, useOracle=False)
+        evals = self.getScores(self.config, self.config, model, useOracle=useOracle)
         annealedOutputs = {
             'samples': self.config,
             'scores': evals[0][0],
@@ -298,10 +300,20 @@ class Sampler:
                 if (self.scores[0][i] < self.E0[i]):
                     self.updateBest(i)
 
-                self.recordTrajectory(i) # if we accept the move, update the trajectory
+                #self.recordTrajectory(i) # if we accept the move, update the trajectory
+
+        self.recordTrajectory()  # if we accept the move, update the trajectory
 
         if self.config_main.debug: # record a bunch of detailed outputs
             self.recordStats()
+
+
+    def recordTrajectory(self):
+        self.all_scores[self.iter] = self.scores[0]
+        self.all_energies[self.iter] = self.energy[0]
+        self.all_uncertainties[self.iter] = self.std_dev[0]
+        self.all_samples[self.iter] = self.propConfig
+
 
     def getDelta(self, scores):
         if self.config_main.STUN == 1:  # compute score difference using STUN
@@ -354,12 +366,6 @@ class Sampler:
 
         return score, energy, std_dev
 
-
-    def recordTrajectory(self, ind):
-        self.all_scores[ind].append(self.scores[0][ind])
-        self.all_energies[ind].append(self.energy[0][ind])
-        self.all_uncertainties[ind].append(self.std_dev[0][ind])
-        self.all_samples[ind].append(self.propConfig[ind])
 
 
     def updateBest(self,ind):

--- a/sampler.py
+++ b/sampler.py
@@ -103,28 +103,31 @@ class Sampler:
         initialize the minimum energies
         :return:
         """
-        self.optima = [[] for i in range(self.nruns)] # record optima of the score function
-        self.enAtOptima = [[] for i in range(self.nruns)]  # record energies near the optima
-        self.std_devAtOptima = [[] for i in range(self.nruns)]  # record of uncertainty at the optima
-        self.optimalSamples = [[] for i in range(self.nruns)]  # record the optimal samples
-        self.optimalInds = [[] for i in range(self.nruns)]
-        self.recInds = [[] for i in range(self.nruns)]
-        self.newOptima = [[] for i in range(self.nruns)] # new minima
-        self.newOptimaEn = [[] for i in range(self.nruns)] # new minima
-        self.allOptimalConfigs = []
+        # trajectory
+        self.all_scores = [[] for i in range(self.nruns)] # record optima of the score function
+        self.all_energies = [[] for i in range(self.nruns)]  # record energies near the optima
+        self.all_uncertainties = [[] for i in range(self.nruns)]  # record of uncertainty at the optima
+        self.all_samples = [[] for i in range(self.nruns)]
 
+        # optima
+        self.new_optima_inds = [[] for i in range(self.nruns)]
+        self.recInds = [[] for i in range(self.nruns)]
+        self.new_optima_scores = [[] for i in range(self.nruns)] # new minima
+        self.new_optima_energies = [[] for i in range(self.nruns)] # new minima
+        self.new_optima_samples = [[] for i in range(self.nruns)] # new minima
 
         # set initial values
         self.E0 = scores[1]  # initialize the 'best score' value
         self.absMin = np.amin(self.E0)
         for i in range(self.nruns):
-            self.optima[i].append(scores[1][i])
-            self.enAtOptima[i].append(energy[1][i])
-            self.std_devAtOptima[i].append(std_dev[1][i])
-            self.newOptima[i].append(self.config[i])
-            self.newOptimaEn[i].append(energy[1][i])
-            self.optimalSamples[i].append(self.config[i])
-            self.optimalInds[i].append(0)
+            self.all_scores[i].append(scores[1][i])
+            self.all_energies[i].append(energy[1][i])
+            self.all_uncertainties[i].append(std_dev[1][i])
+            self.all_samples[i].append(self.config[i])
+            self.new_optima_samples[i].append(self.config[i])
+            self.new_optima_energies[i].append(energy[1][i])
+            self.new_optima_scores[i].append(scores[1][i])
+            self.new_optima_inds[i].append(0)
 
 
     def initRecs(self):
@@ -161,7 +164,15 @@ class Sampler:
         :return:
         """
         self.converge(model, useOracle, nIters = nIters)
-        return self.__dict__
+
+        outputs = {
+            "samples": np.concatenate(self.all_samples),
+            "scores": np.concatenate(self.all_scores),
+            "energies": np.concatenate(self.all_energies),
+            "uncertainties": np.concatenate(self.all_uncertainties),
+        }
+
+        return outputs
 
 
     def converge(self, model, useOracle=False, nIters = False):
@@ -171,10 +182,13 @@ class Sampler:
         """
         self.initConvergenceStats()
         self.resampleRandints()
+
         if nIters is None:
             run_iters = self.config_main.mcmc.sampling_time
         else:
             run_iters = nIters
+
+
         for self.iter in tqdm.tqdm(range(run_iters)):  # sample for a certain number of iterations
             self.iterate(model, useOracle)  # try a monte-carlo step!
 
@@ -184,7 +198,7 @@ class Sampler:
             if self.iter % self.randintsResampleAt == 0: # periodically resample random numbers
                 self.resampleRandints()
 
-        printRecord("{} near-optima were recorded on this run".format(len(self.allOptimalConfigs)))
+        printRecord("{} samples were recorded on this run".format(len(np.concatenate(self.all_samples))))
 
 
     def postSampleAnnealing(self, initConfigs, model, useOracle=False):
@@ -197,13 +211,13 @@ class Sampler:
         '''
         self.config_main.STUN = 0
         self.nruns = len(initConfigs)
-        self.temp0 = 0.01 # initial temperature for sampling runs
+        self.temp0 = 0.01 # initial temperature for sampling runs - start low and shrink
         self.temperature = [self.temp0 for _ in range(self.nruns)]
         self.config = initConfigs # manually overwrite configs
 
         self.initConvergenceStats()
         self.resampleRandints()
-        for self.iter in tqdm.tqdm(range(self.config_main.gflownet.post_annealing_time)):
+        for self.iter in tqdm.tqdm(range(self.config_main.al.annealing_time)):
             self.iterate(model, useOracle)
 
             self.temperature = [temperature * 0.99 for temperature in self.temperature] # cut temperature at every time step
@@ -245,6 +259,7 @@ class Sampler:
                         if nnz > self.config_main.dataset.min_length:
                             self.propConfig[i, nnz - 1] = 0
 
+
     def iterate(self, model, useOracle):
         """
         run chainLength cycles of the sampler
@@ -260,14 +275,13 @@ class Sampler:
         # compute acceptance ratio
         self.scores, self.energy, self.std_dev = self.getScores(self.propConfig, self.config, model, useOracle)
 
-        try:
-            self.E0
-        except:
-            self.initOptima(self.scores, self.energy, self.std_dev)  # if we haven't already assigned E0, initialize everything
+        if self.iter == 0: # initialize optima recording
+            self.initOptima(self.scores, self.energy, self.std_dev)
 
-        self.F, self.DE = self.getDE(self.scores)
+        self.F, self.DE = self.getDelta(self.scores)
         self.acceptanceRatio = np.minimum(1, np.exp(-self.DE / self.temperature))
         self.updateConfigs()
+
 
     def updateConfigs(self):
         '''
@@ -280,17 +294,15 @@ class Sampler:
                 self.config[i] = np.copy(self.propConfig[i])
                 self.recInds[i].append(self.iter)
 
-                newBest = False
                 if (self.scores[0][i] < self.E0[i]):
-                    newBest = True
-                if newBest or ((self.E0[i] - self.scores[0][i]) / self.E0[i] < self.recordMargin):  # if we have a new minimum on this trajectory, record it  # or if near a minimum
-                    self.saveOptima(i, newBest)
+                    self.updateBest(i)
 
+                self.recordTrajectory(i) # if we accept the move, update the trajectory
 
         if self.config_main.debug: # record a bunch of detailed outputs
             self.recordStats()
 
-    def getDE(self, scores):
+    def getDelta(self, scores):
         if self.config_main.STUN == 1:  # compute score difference using STUN
             F = self.computeSTUN(scores)
             DE = F[0] - F[1]
@@ -299,6 +311,7 @@ class Sampler:
             DE = scores[0] - scores[1]
 
         return F, DE
+
 
     def recordStats(self):
         for i in range(self.nruns):
@@ -309,6 +322,7 @@ class Sampler:
             self.std_devrec[i].append(self.std_dev[0][i])
             if self.config_main.STUN:
                 self.stunrec[i].append(self.F[0][i])
+
 
     def getScores(self, propConfig, config, model, useOracle):
         """
@@ -322,12 +336,6 @@ class Sampler:
             std_dev = [[0 for _ in range(len(energy[0]))], [0 for _ in range(len(energy[1]))]]
             score = self.scoreFunction[0] * np.asarray(energy) - self.scoreFunction[1] * np.asarray(std_dev)  # vary the relative importance of these two factors
         else:
-            if (self.config_main.al.query_mode == 'learned') and ('DQN' in str(model.__class__)):
-                score = [model.evaluateQ(np.asarray(config)).cpu().detach().numpy(),model.evaluateQ(np.asarray(propConfig)).cpu().detach().numpy()] # evaluate the q-model
-                score = - np.array((score[1],score[0]))[:,:,0] # this code is a minimizer so we need to flip the sign of the Q scores
-                energy = [np.zeros_like(score[0]), np.zeros_like(score[1])] # energy and variance are irrelevant here
-                std_dev = [np.zeros_like(score[0]), np.zeros_like(score[1])]
-
             if self.config_main.al.query_mode == 'fancy_acquisition':
                 score1, out1, std1 = model.evaluate(np.asarray(config), output='fancy_acquisition')
                 score2, out2, std2 = model.evaluate(np.asarray(propConfig), output='fancy_acquisition')
@@ -346,24 +354,20 @@ class Sampler:
         return score, energy, std_dev
 
 
-    def saveOptima(self, ind, newBest):
-        if len(self.allOptimalConfigs) == 0:
-            [self.allOptimalConfigs.extend(i) for i in self.optimalSamples] # we don't want to duplicate any samples at all, if possible
-        equals = np.sum(self.propConfig[ind] == self.allOptimalConfigs,axis=1)
-        if (not any(equals == self.propConfig[ind].shape[-1])) or newBest: # if there are no copies or we know it's a new minimum, record it # bit slower to keep checking like this but saves us checks later
-            self.optima[ind].append(self.scores[0][ind])
-            self.enAtOptima[ind].append(self.energy[0][ind])
-            self.std_devAtOptima[ind].append(self.std_dev[0][ind])
-            self.optimalSamples[ind].append(self.propConfig[ind])
-            self.allOptimalConfigs.append(self.propConfig[ind])
-        if newBest:
-            self.E0[ind] = self.scores[0][ind]
-            if self.E0[ind] < self.absMin: # if we find a new global minimum, use it
-                self.absMin = self.E0[ind]
-            self.newOptima[ind].append(self.propConfig[ind])
-            self.newOptimaEn[ind].append(self.energy[0][ind])
-            self.optimalInds[ind].append(self.iter)
+    def recordTrajectory(self, ind):
+        self.all_scores[ind].append(self.scores[0][ind])
+        self.all_energies[ind].append(self.energy[0][ind])
+        self.all_uncertainties[ind].append(self.std_dev[0][ind])
+        self.all_samples[ind].append(self.propConfig[ind])
 
+
+    def updateBest(self,ind):
+        self.E0[ind] = self.scores[0][ind]
+        self.absMin = self.E0[ind]
+        self.new_optima_samples[ind].append(self.propConfig[ind])
+        self.new_optima_energies[ind].append(self.energy[0][ind])
+        self.new_optima_scores[ind].append(self.scores[0][ind])
+        self.new_optima_inds[ind].append(self.iter)
 
     def updateAnnealing(self):
         """

--- a/utils.py
+++ b/utils.py
@@ -943,3 +943,4 @@ def add_bool_arg(parser, name, default=False):
     group.add_argument('--' + name, dest=name, action = 'store_true')
     group.add_argument('--no-' + name, dest=name, action = 'store_false')
     parser.set_defaults(**{name:default})
+    return parser

--- a/utils.py
+++ b/utils.py
@@ -371,7 +371,7 @@ def filterDuplicateSamples(samples, oldDatasetPath=None, returnInds=False):
 
 
 def generateRandomSamples(
-    nSamples, sampleLengthRange, dictSize, oldDatasetPath=None, variableLength=True
+    nSamples, sampleLengthRange, dictSize, oldDatasetPath=None, variableLength=True, seed=0
 ):
     """
     randomly generate a non-repeating set of samples of the appropriate size and composition
@@ -381,7 +381,7 @@ def generateRandomSamples(
     :param variableLength:
     :return:
     """
-
+    np.random.seed(seed)
     if variableLength:
         samples = []
         while len(samples) < nSamples:

--- a/utils.py
+++ b/utils.py
@@ -351,27 +351,23 @@ def filterDuplicateSamples(samples, oldDatasetPath=None, returnInds=False):
     seen = set()
     seen_add = seen.add
 
-    if returnInds:
-        filtered = [
-            [samplesTuple[i], i]
-            for i in range(len(samplesTuple))
-            if not (samplesTuple[i] in seen or seen_add(samplesTuple[i]))
-        ]
-        filteredSamples = [filtered[i][0] for i in range(len(filtered))]
-        filteredInds = [filtered[i][1] for i in range(len(filtered))]
+    filtered = [
+        [samplesTuple[i], i]
+        for i in range(len(samplesTuple))
+        if not (samplesTuple[i] in seen or seen_add(samplesTuple[i]))
+    ]
+    filteredSamples = [filtered[i][0] for i in range(len(filtered))][origDatasetLen:] # unique samples
+    filteredInds = [filtered[i][1] for i in range(len(filtered))][origDatasetLen:] # unique sample idxs
 
+    assert len(filteredSamples) > 0, "Sampler returned duplicates only, problem may be completely solved, or sampler is too myopic"
+
+    if returnInds:
         return (
-            np.asarray(filteredSamples[origDatasetLen:]),
-            np.asarray(filteredInds[origDatasetLen:]) - origDatasetLen,
+            np.asarray(filteredSamples),
+            np.asarray(filteredInds) - origDatasetLen, # in samples basis (omitting any prior dataset)
         )
     else:
-        filteredSamples = [
-            samplesTuple[i]
-            for i in range(len(samplesTuple))
-            if not (samplesTuple[i] in seen or seen_add(samplesTuple[i]))
-        ]
-
-        return np.asarray(filteredSamples[origDatasetLen:])
+        return np.asarray(filteredSamples)
 
 
 def generateRandomSamples(
@@ -429,18 +425,6 @@ def generateRandomSamples(
 
     return samples
 
-
-def samples2dict(samples):
-    """
-    Returns key outputs in a dictionary
-    """
-    outputs = {
-        "samples": np.concatenate(samples["optimalSamples"]),
-        "scores": np.concatenate(samples["optima"]),
-        "energies": np.concatenate(samples["enAtOptima"]),
-        "uncertainties": np.concatenate(samples["std_devAtOptima"]),
-    }
-    return outputs
 
 
 def get_n_params(model):
@@ -518,6 +502,7 @@ def filterOutputs(outputs, additionalEntries=None):
         "uncertainties": uncertainties[filteredInds],
     }
     printRecord('Sampler outputs after filtering - best energy = {:.4f}'.format(np.amin(energies)))
+
     return filteredOutputs
 
 
@@ -930,3 +915,31 @@ def numpy2python(results_dict):
 def normalizeDistCutoff(cutoff):
     return (1 + np.tanh(cutoff)) / 2
 
+
+def bracket_dot_to_num(sequences, maxlen):
+    '''
+    convert from (((...))) notation to 111222333
+    '''
+    my_seq = np.zeros((len(sequences), maxlen))
+    row = 0
+
+    for seq in sequences:
+        col = 0
+        for na in seq:
+            if na == "(":
+                my_seq[row, col] = 1
+            elif na == ".":
+                my_seq[row, col] = 2
+            elif na == ")":
+                my_seq[row, col] = 3
+            col += 1
+        row += 1
+
+    return my_seq
+
+
+def add_bool_arg(parser, name, default=False):
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument('--' + name, dest=name, action = 'store_true')
+    group.add_argument('--no-' + name, dest=name, action = 'store_false')
+    parser.set_defaults(**{name:default})

--- a/utils.py
+++ b/utils.py
@@ -371,7 +371,7 @@ def filterDuplicateSamples(samples, oldDatasetPath=None, returnInds=False):
 
 
 def generateRandomSamples(
-    nSamples, sampleLengthRange, dictSize, oldDatasetPath=None, variableLength=True, seed=0
+    nSamples, sampleLengthRange, dictSize, oldDatasetPath=None, variableLength=True, seed=None
 ):
     """
     randomly generate a non-repeating set of samples of the appropriate size and composition
@@ -381,7 +381,8 @@ def generateRandomSamples(
     :param variableLength:
     :return:
     """
-    np.random.seed(seed)
+    if seed is not None:
+        np.random.seed(seed)
     if variableLength:
         samples = []
         while len(samples) < nSamples:


### PR DESCRIPTION
Big PR - tested with several nupack oracles, MCMC, random, GFN, energy and heuristic acquisition functions.

- added new nupack oracles (open loop size and distance from target f……old) with an optional stability reweighting
- simplified model state calculation - fast (random with anealing) during the run, and then one at the end using whichever sampler is building queries (often more expensive). Also made it simpler / faster overall: added a toggle for large data loss calculation, reduced samples for random distance calculation, reduced samples for large data loss calculation.
- unified all oracles as being negative everywhere, directly from oracles.py
- unified language mostly everywhere for 'scores' vs 'energies' - for now, if it comes out of an oracle, it's an 'energy', (this is the value we are trying to optimize, whether or not it's actually 'energy' i.e. it could be the number of hairpins) and if it's an output of an acquisition function, it's a 'score' - i.e. may be mixed with uncertainty
- various small cleanups
- obviated oracle.py - we can now run oracles directly in AptamerSeq by feeding it oracle.score (for from oracles import Oracle, oracle = Oracle(config)), instead of calling specific functions
- adjusted gflownet.py for sampling from oracle - some tweaks still to be made here and in config